### PR TITLE
Add support for `Nativeint` and `Int`  data kinds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,68 +2,57 @@
 An implementation of the Zarr version 3 specification.
 
 
-## Example
+## Usage Example
+Below is a demonstration of the library's basic API.
+### setup
 ```ocaml
 open Zarr
 open Zarr.Codecs
 open Zarr.Storage
 open Zarr.Metadata
 open Zarr.Extensions
+
 module Ndarray = Owl.Dense.Ndarray.Generic
 
 let store =
   Result.get_ok @@
   FilesystemStore.open_or_create ~file_perm:0o777 "testdata.zarr";;
-
+```
+### create group
+```ocaml
 let group_node =
   Result.get_ok @@ Node.of_path "/some/group";;
 
 FilesystemStore.create_group store group_node;;
-
+```
+### create an array
+```ocaml
 let array_node =
   Result.get_ok @@ Node.(group_node / "name");;
 
-let shard_config = {
-  chunk_shape = [|5; 5; 10|];
-  codecs = Chain.create [] (Bytes Little) [Gzip L5];
-  index_codecs = Chain.create [] (Bytes Big) [Crc32c];
-  index_location = Start
-};;
 let codec_chain =
-  Chain.create [Transpose [|0; 1; 2|]] (ShardingIndexed shard_config) [];;
+  {a2a = [Transpose [|2; 0; 1|]]
+  ;a2b = Bytes Big
+  ;b2b = [Gzip L2]};;
 
 FilesystemStore.create_array
   ~codecs:codec_chain
   ~shape:[|100; 100; 50|]
-  ~chunks:[|15; 15; 20|]
-  (FillValue.Float Float.neg_infinity)
-  Datatype.Float32
+  ~chunks:[|10; 15; 20|]
+  Bigarray.Float32 
+  Float.neg_infinity
   array_node
   store;;
-
-FilesystemStore.find_all_nodes store |> List.map Node.to_path;;
-(* - : string list = ["/"; "/some"; "/some/group/name"; "/some/group"] *)
-
+```
+### open and write to an array
+```ocaml
 let slice = Owl_types.[|R [0; 20]; I 10; R []|];;
 let x =
   Result.get_ok @@
   FilesystemStore.get_array array_node slice Bigarray.Float32 store;;
-(*
-          C0   C1   C2   C3   C4      C45  C46  C47  C48  C49 
- R[0,0] -INF -INF -INF -INF -INF ... -INF -INF -INF -INF -INF 
- R[1,0] -INF -INF -INF -INF -INF ... -INF -INF -INF -INF -INF 
- R[2,0] -INF -INF -INF -INF -INF ... -INF -INF -INF -INF -INF 
- R[3,0] -INF -INF -INF -INF -INF ... -INF -INF -INF -INF -INF 
- R[4,0] -INF -INF -INF -INF -INF ... -INF -INF -INF -INF -INF 
-         ...  ...  ...  ...  ... ...  ...  ...  ...  ...  ... 
-R[16,0] -INF -INF -INF -INF -INF ... -INF -INF -INF -INF -INF 
-R[17,0] -INF -INF -INF -INF -INF ... -INF -INF -INF -INF -INF 
-R[18,0] -INF -INF -INF -INF -INF ... -INF -INF -INF -INF -INF 
-R[19,0] -INF -INF -INF -INF -INF ... -INF -INF -INF -INF -INF 
-R[20,0] -INF -INF -INF -INF -INF ... -INF -INF -INF -INF -INF *)
 
 (* Do some computation on the array slice *)
-let x' = Ndarray.map (fun _ -> Owl_stats_dist.uniform_rvs 0. 100.) x;;
+let x' = Ndarray.map (fun _ -> Owl_stats_dist.uniform_rvs 0. 10.) x;;
 FilesystemStore.set_array array_node slice x' store;;
 
 FilesystemStore.get_array
@@ -71,42 +60,63 @@ FilesystemStore.get_array
   Owl_types.[|R [0; 73]; L [10; 16]; R[0; 5]|]
   Bigarray.Float32
   store;;
-(*
-             C0      C1      C2      C3      C4      C5 
- R[0,0] 68.0272  44.914 85.2431 39.0772  26.582  16.577 
- R[0,1]    -INF    -INF    -INF    -INF    -INF    -INF 
- R[1,0]  88.418 77.0368 43.4968 45.1263 8.95641 76.9155 
- R[1,1]    -INF    -INF    -INF    -INF    -INF    -INF 
- R[2,0] 98.4036 77.8744 67.6689 56.8803 37.0718  97.042 
-            ...     ...     ...     ...     ...     ... 
-R[71,1]    -INF    -INF    -INF    -INF    -INF    -INF 
-R[72,0]    -INF    -INF    -INF    -INF    -INF    -INF 
-R[72,1]    -INF    -INF    -INF    -INF    -INF    -INF 
-R[73,0]    -INF    -INF    -INF    -INF    -INF    -INF 
-R[73,1]    -INF    -INF    -INF    -INF    -INF    -INF *)
+(*           C0      C1       C2       C3      C4       C5 
+ R[0,0]   6.106 4.76659   2.6251  5.76799 3.95144  1.95656 
+ R[0,1]    -INF    -INF     -INF     -INF    -INF     -INF 
+ R[1,0] 7.31409 6.64764 0.980762 0.530332 4.17086  5.45735 
+ R[1,1]    -INF    -INF     -INF     -INF    -INF     -INF 
+ R[2,0] 3.52729 5.15036 0.488728  4.40894 7.62077 0.891417 
+            ...     ...      ...      ...     ...      ... 
+R[71,1]    -INF    -INF     -INF     -INF    -INF     -INF 
+R[72,0]    -INF    -INF     -INF     -INF    -INF     -INF 
+R[72,1]    -INF    -INF     -INF     -INF    -INF     -INF 
+R[73,0]    -INF    -INF     -INF     -INF    -INF     -INF 
+R[73,1]    -INF    -INF     -INF     -INF    -INF     -INF *)
+```
+### create an array with sharding
+```ocaml
+let config =
+  {chunk_shape = [|10; 3; 5|]
+  ;codecs =
+    {a2a = [Transpose [|2; 0; 1|]]
+    ;a2b = Bytes Little
+    ;b2b = [Gzip L5]}
+  ;index_codecs =
+    {a2a = []
+    ;a2b = Bytes Big
+    ;b2b = [Crc32c]}
+  ;index_location = Start};;
+let codec_chain =
+  {a2a = []
+  ;a2b = ShardingIndexed config
+  ;b2b = [Crc32c]};;
+
+let shard_node = Result.get_ok @@ Node.(group_node / "another");;
+
+FilesystemStore.create_array
+  ~codecs:codec_chain
+  ~shape:[|100; 100; 50|]
+  ~chunks:[|10; 15; 20|]
+  Bigarray.Complex32
+  Complex.zero
+  shard_node
+  store;;
+```
+### More functions
+```ocaml
+FilesystemStore.find_all_nodes store |> List.map Node.to_path;;
+(* - : string list = ["/"; "/some"; "/some/group/another"; "/some/group/name"; "/some/group"] *)
 
 FilesystemStore.reshape store array_node [|25; 32; 10|];;
-FilesystemStore.get_array
-  array_node
-  Owl_types.[|R []; I 10; R[0; 5]|]
-  Bigarray.Float32
-  store;;
-(*
-             C0      C1      C2      C3      C4      C5 
- R[0,0] 68.0272  44.914 85.2431 39.0772  26.582  16.577 
- R[1,0]  88.418 77.0368 43.4968 45.1263 8.95641 76.9155 
- R[2,0] 98.4036 77.8744 67.6689 56.8803 37.0718  97.042 
- R[3,0] 22.8653 20.1767 88.9549 22.1052 9.86822 10.8826 
- R[4,0] 55.6043 93.8599 60.3723  40.543 46.8199  97.282 
-            ...     ...     ...     ...     ...     ... 
-R[20,0] 61.2473 78.8035 52.3056 59.5631 78.2462 52.4205 
-R[21,0]    -INF    -INF    -INF    -INF    -INF    -INF 
-R[22,0]    -INF    -INF    -INF    -INF    -INF    -INF 
-R[23,0]    -INF    -INF    -INF    -INF    -INF    -INF 
-R[24,0]    -INF    -INF    -INF    -INF    -INF    -INF *)
 
 FilesystemStore.array_metadata array_node store
 |> Result.get_ok
 |> ArrayMetadata.shape;;
 (* - : int array = [|25; 32; 10|] *)
+
+FilesystemStore.is_member store shard_node;;
+
+FilesystemStore.find_child_nodes store group_node;;
+
+FilesystemStore.erase_node store group_node;;
 ```

--- a/lib/codecs/array_to_array.mli
+++ b/lib/codecs/array_to_array.mli
@@ -9,7 +9,15 @@ type error =
   [ `Invalid_transpose_order of dimension_order * string ]
 
 module ArrayToArray : sig 
+  val parse
+    : ('a, 'b) Util.array_repr ->
+      array_to_array ->
+      (unit, [> error]) result
   val compute_encoded_size : int -> array_to_array -> int
+  val compute_encoded_representation
+    : array_to_array ->
+      ('a, 'b) Util.array_repr ->
+      ('a, 'b) Util.array_repr
   val encode
     : array_to_array ->
       ('a, 'b) Ndarray.t ->

--- a/lib/codecs/array_to_bytes.mli
+++ b/lib/codecs/array_to_bytes.mli
@@ -23,10 +23,15 @@ and chain = {
 type error =
   [ `Bytes_encode_error of string
   | `Bytes_decode_error of string
+  | `Sharding_shape_mismatch of int array * int array
   | Array_to_array.error
   | Bytes_to_bytes.error ]
 
 module ArrayToBytes : sig
+  val parse
+    : ('a, 'b) Util.array_repr ->
+      array_to_bytes ->
+      (unit, [> error]) result
   val compute_encoded_size : int -> array_to_bytes -> int
   val default : array_to_bytes
   val encode

--- a/lib/codecs/codecs.mli
+++ b/lib/codecs/codecs.mli
@@ -35,12 +35,10 @@ and chain = {
 type error = Array_to_bytes.error
 
 module Chain : sig
-  type t = chain
+  type t
 
   val create
-    : array_to_array list ->
-      array_to_bytes ->
-      bytes_to_bytes list -> t
+    : ('a, 'b) Util.array_repr -> chain -> (t, [> error]) result
 
   val default : t
 

--- a/lib/codecs/ebuffer.ml
+++ b/lib/codecs/ebuffer.ml
@@ -11,6 +11,8 @@ module type S = sig
   val add_float64 : Buffer.t -> float -> unit
   val add_complex32 : Buffer.t -> Complex.t -> unit
   val add_complex64 : Buffer.t -> Complex.t -> unit
+  val add_int : Buffer.t -> int -> unit
+  val add_nativeint : Buffer.t -> nativeint -> unit
 
   val get_char : string -> int -> char
   val get_int8 : string -> int -> int 
@@ -23,6 +25,8 @@ module type S = sig
   val get_float64 : string -> int -> float
   val get_complex32 : string -> int -> Complex.t
   val get_complex64 : string -> int -> Complex.t
+  val get_int : string -> int -> int
+  val get_nativeint : string -> int -> nativeint
 end
 
 module Little = struct
@@ -34,6 +38,8 @@ module Little = struct
   let add_uint16 = Buffer.add_uint16_le
   let add_int32 = Buffer.add_int32_le
   let add_int64 = Buffer.add_int64_le
+  let add_int buf v = Int64.of_int v |> add_int64 buf
+  let add_nativeint buf v = Int64.of_nativeint v |> add_int64 buf
   let add_float32 buf v = Int32.bits_of_float v |> add_int32 buf
   let add_float64 buf v = Int64.bits_of_float v |> add_int64 buf
   let add_complex32 buf Complex.{re; im} = 
@@ -50,6 +56,8 @@ module Little = struct
   let get_uint16 = String.get_uint16_le
   let get_int32 = String.get_int32_le
   let get_int64 = String.get_int64_le
+  let get_int buf i = get_int64 buf i |> Int64.to_int
+  let get_nativeint buf i = get_int64 buf i |> Int64.to_nativeint
   let get_float32 buf i = get_int32 buf i |> Int32.float_of_bits
   let get_float64 buf i = get_int64 buf i |> Int64.float_of_bits
   let get_complex32 buf i =
@@ -69,6 +77,8 @@ module Big = struct
   let add_uint16 = Buffer.add_uint16_be
   let add_int32 = Buffer.add_int32_be
   let add_int64 = Buffer.add_int64_be
+  let add_int buf v = Int64.of_int v |> add_int64 buf
+  let add_nativeint buf v = Int64.of_nativeint v |> add_int64 buf
   let add_float32 buf v = Int32.bits_of_float v |> Buffer.add_int32_be buf
   let add_float64 buf v = Int64.bits_of_float v |> Buffer.add_int64_be buf
   let add_complex32 buf Complex.{re; im} = 
@@ -85,6 +95,8 @@ module Big = struct
   let get_uint16 = String.get_uint16_be
   let get_int32 = String.get_int32_be
   let get_int64 = String.get_int64_be
+  let get_int buf i = get_int64 buf i |> Int64.to_int
+  let get_nativeint buf i = get_int64 buf i |> Int64.to_nativeint
   let get_float32 buf i = get_int32 buf i |> Int32.float_of_bits
   let get_float64 buf i = get_int64 buf i |> Int64.float_of_bits
   let get_complex32 buf i =

--- a/lib/codecs/ebuffer.mli
+++ b/lib/codecs/ebuffer.mli
@@ -11,6 +11,8 @@ module type S = sig
   val add_float64 : Buffer.t -> float -> unit
   val add_complex32 : Buffer.t -> Complex.t -> unit
   val add_complex64 : Buffer.t -> Complex.t -> unit
+  val add_int : Buffer.t -> int -> unit
+  val add_nativeint : Buffer.t -> nativeint -> unit
 
   val get_char : string -> int -> char
   val get_int8 : string -> int -> int 
@@ -23,6 +25,8 @@ module type S = sig
   val get_float64 : string -> int -> float
   val get_complex32 : string -> int -> Complex.t
   val get_complex64 : string -> int -> Complex.t
+  val get_int : string -> int -> int
+  val get_nativeint : string -> int -> nativeint
 end
 
 module Little : sig include S end

--- a/lib/extensions.ml
+++ b/lib/extensions.ml
@@ -111,6 +111,23 @@ module Datatype = struct
     | Float64
     | Complex32
     | Complex64
+    | Int
+    | Nativeint
+
+  let of_kind : type a b. (a, b) Bigarray.kind -> t = function
+    | Bigarray.Char -> Char
+    | Bigarray.Int8_signed -> Int8
+    | Bigarray.Int8_unsigned -> Uint8
+    | Bigarray.Int16_signed -> Int16
+    | Bigarray.Int16_unsigned -> Uint16
+    | Bigarray.Int32 -> Int32
+    | Bigarray.Int64 -> Int64
+    | Bigarray.Float32 -> Float32
+    | Bigarray.Float64 -> Float64
+    | Bigarray.Complex32 -> Complex32
+    | Bigarray.Complex64 -> Complex64
+    | Bigarray.Int -> Int
+    | Bigarray.Nativeint -> Nativeint
 
   let to_yojson = function
     | Char -> `String "char"
@@ -124,6 +141,8 @@ module Datatype = struct
     | Float64 -> `String "float64"
     | Complex32 -> `String "complex32"
     | Complex64 -> `String "complex64"
+    | Int -> `String "int"
+    | Nativeint -> `String "nativeint"
 
   let of_yojson = function
     | `String "char" -> Ok Char
@@ -137,5 +156,7 @@ module Datatype = struct
     | `String "float64" -> Ok Float64
     | `String "complex32" -> Ok Complex32
     | `String "complex64" -> Ok Complex64
+    | `String "int" -> Ok Int
+    | `String "nativeint" -> Ok Nativeint
     | _ -> Error ("Unsupported metadata data_type")
 end

--- a/lib/extensions.mli
+++ b/lib/extensions.mli
@@ -37,8 +37,11 @@ module Datatype : sig
     | Float64
     | Complex32
     | Complex64
+    | Int
+    | Nativeint
   (** A type for the supported data types of a Zarr array. *)
 
+  val of_kind : ('a, 'b) Bigarray.kind -> t
   val of_yojson : Yojson.Safe.t -> (t, string) result
   val to_yojson : t -> Yojson.Safe.t
 end

--- a/lib/metadata.mli
+++ b/lib/metadata.mli
@@ -13,7 +13,7 @@ module FillValue : sig
   type t =
     | Char of char  (** A single character string. *)
     | Bool of bool  (** Must be a JSON boolean. *)
-    | Int of int  (** Value must be a JSON number with no fractional or exponent part that is within the representable range of the corresponding integer data type. *)
+    | Int of int64  (** Value must be a JSON number with no fractional or exponent part that is within the representable range of the corresponding integer data type. *)
     | Float of float  (** Value representing a JSON float. *)
     | FloatBits of float  (** A JSON string specifying a byte representation of the float a hexstring. *)
     | IntComplex of Complex.t  (** A JSON 2-element array of integers representing a complex number. *)
@@ -37,12 +37,12 @@ module ArrayMetadata : sig
     ?sep:Extensions.separator ->
     ?codecs:Codecs.Chain.t  ->
     shape:int array ->
-    FillValue.t ->
-    Extensions.Datatype.t ->
+    ('a, 'b) Bigarray.kind ->
+    'a ->
     int array ->
     t
-  (** [create ~shape fv dtype cshp] Creates a new array metadata document
-      with shape [shape], fill value [fv], data type [dtype] and chunk shape
+  (** [create ~shape kind fv cshp] Creates a new array metadata document
+      with shape [shape], fill value [fv], data type [kind] and chunk shape
       [cshp]. *)
 
   val encode : t -> string

--- a/lib/node.ml
+++ b/lib/node.ml
@@ -15,11 +15,9 @@ let rep_ok name =
 
 let root = Root 
 
-let unsafe_create p n = Cons (p, n)
-
 let create parent name =
   if rep_ok name then
-    Ok (unsafe_create parent name)
+    Result.ok @@ Cons (parent, name)
   else
     Error (`Node_invariant_error name)
 
@@ -35,10 +33,10 @@ let of_path = function
       Result.error @@
       `Node_invariant_error "path should not end with a /"
     else 
-      Result.ok @@
+      let open Util.Result_syntax in
       List.fold_left
-        unsafe_create
-        Root (List.tl @@ String.split_on_char '/' str)
+        (fun acc n -> acc >>= fun p -> create p n)
+        (Ok Root) (List.tl @@ String.split_on_char '/' str)
 
 let name = function
   | Root -> ""


### PR DESCRIPTION
Also:
-This commit fixes a bug where subsequent codecs were not
aware of the Transpose codec's encoded representation. Meaning if
the transpose changed the encoded representation's shape compared to
its decoded representation, this information was not propagated to
subsequent codecs when decoding chunks, which lead to an
Out of index exception getting thrown when decoding a chunk
of an array that contains the Transpose codec in its codec chain.

-This commit strengthens the construction of a node via
`Node.of_path` by checking the node invariants are not
violated at every stage of the node construction.