### PR TITLE
Add unit tests for Group metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ FilesystemStore.find_all_nodes store |> List.map Node.to_path;;
 
 FilesystemStore.reshape store array_node [|25; 32; 10|];;
 
-FilesystemStore.array_metadata array_node store
-|> Result.get_ok
-|> ArrayMetadata.shape;;
-(* - : int array = [|25; 32; 10|] *)
+let meta =
+  Result.get_ok @@
+  FilesystemStore.group_metadata group_node store;;
+GroupMetadata.show meta;; (* pretty prints the contents of the metadata *)
 
 FilesystemStore.is_member store shard_node;;
 

--- a/lib/dune
+++ b/lib/dune
@@ -11,7 +11,9 @@
  (ocamlopt_flags
    (:standard -O3))
  (preprocess
-   (pps ppx_deriving_yojson))
+   (pps
+     ppx_deriving.show
+     ppx_deriving_yojson))
  (instrumentation
    (backend bisect_ppx)))
 

--- a/lib/metadata.ml
+++ b/lib/metadata.ml
@@ -227,11 +227,11 @@ module GroupMetadata = struct
   type t =
     {zarr_format : int
     ;node_type : string
-    ;attributes : Yojson.Safe.t option [@yojson.option]}
-  [@@deriving yojson]
+    ;attributes : Yojson.Safe.t [@default `Null]}
+  [@@deriving yojson, show]
 
   let default =
-    {zarr_format = 3; node_type = "group"; attributes = None}
+    {zarr_format = 3; node_type = "group"; attributes = `Null}
 
   let decode s = 
     let open Util.Result_syntax in
@@ -241,6 +241,6 @@ module GroupMetadata = struct
   let encode t =
     Yojson.Safe.to_string @@ to_yojson t
 
-  let update_attributes attrs t =
-    {t with attributes = Some attrs}
+  let update_attributes t attrs =
+    {t with attributes = attrs}
 end

--- a/lib/metadata.mli
+++ b/lib/metadata.mli
@@ -138,8 +138,8 @@ module GroupMetadata : sig
   (** [decode s] decodes a bytes string [s] into a {!GroupMetadata.t}
       type, and returns an {!Metadata.error} error if the decoding process fails. *)
 
-  val update_attributes : Yojson.Safe.t -> t -> t
-  (** [update_attributes json t] returns a new metadata type with an updated
+  val update_attributes : t -> Yojson.Safe.t -> t
+  (** [update_attributes t json] returns a new metadata type with an updated
       attribute field containing contents in [json]. *)
 
   val of_yojson : Yojson.Safe.t -> (t, string) result
@@ -148,4 +148,7 @@ module GroupMetadata : sig
 
   val to_yojson : t -> Yojson.Safe.t
   (** [to_yojson t] serializes a group metadata type into a {!Yojson.Safe.t} object. *)
+
+  val show : t -> string
+  (** [show t] pretty-prints the contents of the group metadata type t. *)
 end

--- a/test/test_metadata.ml
+++ b/test/test_metadata.ml
@@ -1,0 +1,27 @@
+open OUnit2
+open Zarr
+
+let group = [
+
+"group metadata" >:: (fun _ ->
+  let meta = GroupMetadata.default in
+  let expected = {|{"zarr_format":3,"node_type":"group"}|} in
+  let got = GroupMetadata.encode meta in
+  assert_equal expected got;
+
+  (match GroupMetadata.decode got with
+  | Ok v ->
+    assert_equal ~printer:GroupMetadata.show meta v;
+  | Error _ ->
+    assert_bool "Decoding well formed metadata should not fail" false);
+  assert_bool "" (Result.is_error @@ GroupMetadata.decode {|{"bad_json":0}|});
+
+  let meta' =
+    GroupMetadata.update_attributes
+      meta @@ `Assoc [("spam", `String "ham"); ("eggs", `Int 42)]
+  in
+  let expected =
+    {|{"zarr_format":3,"node_type":"group","attributes":{"spam":"ham","eggs":42}}|}
+  in
+  assert_equal expected @@ GroupMetadata.encode meta')
+]

--- a/test/test_zarr.ml
+++ b/test/test_zarr.ml
@@ -4,6 +4,7 @@ open OUnit2
 let () =
   let suite = "Run All tests" >:::
       Test_node.tests @
-      Test_indexing.tests
+      Test_indexing.tests @
+      Test_metadata.group
   in
   run_test_tt_main suite


### PR DESCRIPTION
This commit also adds a `show` function to pretty print group metadata contents. It also ensures that the optional attributes fields is not required if JSON does not include it and also does not export it if it is not specified when creating a GroupMetadata type object.