### PR TITLE
Add unit tests for `ArrayMetadata` module.

### DIFF
--- a/lib/codecs/array_to_array.ml
+++ b/lib/codecs/array_to_array.ml
@@ -1,9 +1,10 @@
 module Ndarray = Owl.Dense.Ndarray.Generic
 
-type dimension_order = int array
+type dimension_order = int array [@@deriving show]
 
 type array_to_array =
   | Transpose of dimension_order
+  [@@deriving show]
 
 type error =
   [ `Invalid_transpose_order of dimension_order * string ]

--- a/lib/codecs/array_to_array.ml
+++ b/lib/codecs/array_to_array.ml
@@ -11,7 +11,7 @@ type error =
 (* https://zarr-specs.readthedocs.io/en/latest/v3/codecs/transpose/v1.0.html *)
 module TransposeCodec = struct
   type config = {order : int array} [@@deriving yojson]
-  type transpose = config Util.ext_point  [@@deriving yojson]
+  type transpose = config Util.ExtPoint.t  [@@deriving yojson]
 
   let compute_encoded_size input_size = input_size
 

--- a/lib/codecs/array_to_array.mli
+++ b/lib/codecs/array_to_array.mli
@@ -8,6 +8,9 @@ type array_to_array =
 type error =
   [ `Invalid_transpose_order of dimension_order * string ]
 
+val pp_array_to_array : Format.formatter -> array_to_array -> unit
+val show_array_to_array : array_to_array -> string
+
 module ArrayToArray : sig 
   val parse
     : ('a, 'b) Util.array_repr ->

--- a/lib/codecs/array_to_bytes.ml
+++ b/lib/codecs/array_to_bytes.ml
@@ -34,7 +34,7 @@ type error =
 (* https://zarr-specs.readthedocs.io/en/latest/v3/codecs/bytes/v1.0.html *)
 module BytesCodec = struct
   type config = {endian : string} [@@deriving yojson]
-  type bytes = config Util.ext_point [@@deriving yojson]
+  type bytes = config Util.ExtPoint.t [@@deriving yojson]
   type t = endianness
 
   let compute_encoded_size (input_size : int) = input_size

--- a/lib/codecs/array_to_bytes.ml
+++ b/lib/codecs/array_to_bytes.ml
@@ -4,13 +4,20 @@ open Util.Result_syntax
 
 module Ndarray = Owl.Dense.Ndarray.Generic
 
-type endianness = Little | Big
+type endianness =
+  | Little
+  | Big
+  [@@deriving show]
 
-type loc = Start | End
+type loc =
+  | Start
+  | End
+  [@@deriving show]
 
 type array_to_bytes =
   | Bytes of endianness
   | ShardingIndexed of shard_config
+  [@@deriving show]
 
 and shard_config =
   {chunk_shape : int array
@@ -18,11 +25,11 @@ and shard_config =
   ;index_codecs : chain
   ;index_location : loc}
 
-and chain = {
-  a2a: array_to_array list;
-  a2b: array_to_bytes;
-  b2b: bytes_to_bytes list;
-}
+and chain =
+  {a2a: array_to_array list
+  ;a2b: array_to_bytes
+  ;b2b: bytes_to_bytes list}
+  [@@deriving show]
 
 type error =
   [ `Bytes_encode_error of string

--- a/lib/codecs/array_to_bytes.mli
+++ b/lib/codecs/array_to_bytes.mli
@@ -20,6 +20,9 @@ and chain = {
   b2b: Bytes_to_bytes.bytes_to_bytes list;
 }
 
+val pp_chain : Format.formatter -> chain -> unit
+val show_chain : chain -> string
+
 type error =
   [ `Bytes_encode_error of string
   | `Bytes_decode_error of string

--- a/lib/codecs/bytes_to_bytes.ml
+++ b/lib/codecs/bytes_to_bytes.ml
@@ -13,7 +13,7 @@ type error =
 (* https://zarr-specs.readthedocs.io/en/latest/v3/codecs/gzip/v1.0.html *)
 module GzipCodec = struct
   type config = {level : int} [@@deriving yojson]
-  type gzip = config Util.ext_point [@@deriving yojson]
+  type gzip = config Util.ExtPoint.t [@@deriving yojson]
 
   let compute_encoded_size _ =
     failwith "Cannot compute encoded size of Gzip codec."

--- a/lib/codecs/bytes_to_bytes.ml
+++ b/lib/codecs/bytes_to_bytes.ml
@@ -2,10 +2,12 @@ module Ndarray = Owl.Dense.Ndarray.Generic
 
 type compression_level =
   | L0 | L1 | L2 | L3 | L4 | L5 | L6 | L7 | L8 | L9
+  [@@deriving show]
 
 type bytes_to_bytes =
   | Crc32c
   | Gzip of compression_level
+  [@@deriving show]
 
 type error = 
   [ `Gzip of Ezgzip.error ]

--- a/lib/codecs/bytes_to_bytes.mli
+++ b/lib/codecs/bytes_to_bytes.mli
@@ -10,6 +10,9 @@ type bytes_to_bytes =
 type error = 
   [ `Gzip of Ezgzip.error ]
 
+val pp_bytes_to_bytes : Format.formatter -> bytes_to_bytes -> unit
+val show_bytes_to_bytes : bytes_to_bytes -> string
+
 module BytesToBytes : sig
   val compute_encoded_size : int -> bytes_to_bytes -> int
   val encode : bytes_to_bytes -> string -> (string, [> error]) result

--- a/lib/codecs/codecs.ml
+++ b/lib/codecs/codecs.ml
@@ -50,6 +50,9 @@ module Chain = struct
       (fun c acc -> acc >>= ArrayToArray.decode c)
       t.a2a (ArrayToBytes.decode y repr' t.a2b)
 
+  let equal x y =
+    x.a2a = y.a2a && x.a2b = y.a2b && x.b2b = y.b2b
+
   let to_yojson t =
     [%to_yojson: Yojson.Safe.t list] @@ 
     List.map ArrayToArray.to_yojson t.a2a @

--- a/lib/codecs/codecs.ml
+++ b/lib/codecs/codecs.ml
@@ -8,6 +8,10 @@ module Ndarray = Owl.Dense.Ndarray.Generic
 module Chain = struct
   type t = chain
 
+  let pp = pp_chain
+
+  let show = show_chain
+
   let create repr {a2a; a2b; b2b} =
     List.fold_left
       (fun acc c ->

--- a/lib/codecs/codecs.mli
+++ b/lib/codecs/codecs.mli
@@ -58,4 +58,8 @@ module Chain : sig
   val of_yojson : Yojson.Safe.t -> (t, string) result
 
   val to_yojson : t -> Yojson.Safe.t
+
+  val pp : Format.formatter -> t -> unit
+
+  val show : t -> string
 end

--- a/lib/codecs/codecs.mli
+++ b/lib/codecs/codecs.mli
@@ -53,6 +53,8 @@ module Chain : sig
       string ->
       (('a, 'b) Ndarray.t, [> error]) result
 
+  val equal : t -> t -> bool
+
   val of_yojson : Yojson.Safe.t -> (t, string) result
 
   val to_yojson : t -> Yojson.Safe.t

--- a/lib/dune
+++ b/lib/dune
@@ -12,6 +12,7 @@
    (:standard -O3))
  (preprocess
    (pps
+     ppx_deriving.eq
      ppx_deriving.show
      ppx_deriving_yojson))
  (instrumentation

--- a/lib/extensions.ml
+++ b/lib/extensions.ml
@@ -4,7 +4,7 @@ module RegularGrid = struct
   type config =
     {chunk_shape : int array} [@@deriving yojson]
   type chunk_grid =
-    config Util.ext_point [@@deriving yojson]
+    config Util.ExtPoint.t [@@deriving yojson]
   type t = int array
 
   let chunk_shape t = t
@@ -33,6 +33,8 @@ module RegularGrid = struct
     |> Util.Indexing.cartesian_prod
     |> List.map Array.of_list
 
+  let equal : t -> t -> bool = fun x y -> x = y
+
   let to_yojson t =
     chunk_grid_to_yojson
       {name = "regular"; configuration = {chunk_shape = t}}
@@ -50,7 +52,7 @@ type separator = Dot | Slash
 module ChunkKeyEncoding = struct
   type encoding = Default | V2
   type config = {separator : string} [@@deriving yojson]
-  type key_encoding = config Util.ext_point [@@deriving yojson]
+  type key_encoding = config Util.ExtPoint.t [@@deriving yojson]
   type t = {encoding : encoding; sep : string}
 
   let create = function
@@ -73,6 +75,9 @@ module ChunkKeyEncoding = struct
       else
         String.concat t.sep @@
         Array.fold_right f index []
+
+  let equal x y =
+    x.encoding = y.encoding && x.sep = y.sep
 
   let to_yojson t =
     match t.encoding with
@@ -113,6 +118,8 @@ module Datatype = struct
     | Complex64
     | Int
     | Nativeint
+
+  let equal : t -> t -> bool = fun x y -> x = y
 
   let of_kind : type a b. (a, b) Bigarray.kind -> t = function
     | Bigarray.Char -> Char

--- a/lib/extensions.mli
+++ b/lib/extensions.mli
@@ -5,6 +5,7 @@ module RegularGrid : sig
   val grid_shape : t -> int array -> int array
   val indices : t -> int array -> int array list
   val index_coord_pair : t -> int array -> int array * int array
+  val equal : t -> t -> bool
   val of_yojson : Yojson.Safe.t -> (t, string) result
   val to_yojson : t -> Yojson.Safe.t
 end
@@ -18,6 +19,7 @@ module ChunkKeyEncoding : sig
   type t
   val create : separator -> t
   val encode : t -> int array -> string
+  val equal : t -> t -> bool
   val of_yojson : Yojson.Safe.t -> (t, string) result
   val to_yojson : t -> Yojson.Safe.t
 end
@@ -41,6 +43,7 @@ module Datatype : sig
     | Nativeint
   (** A type for the supported data types of a Zarr array. *)
 
+  val equal : t -> t -> bool
   val of_kind : ('a, 'b) Bigarray.kind -> t
   val of_yojson : Yojson.Safe.t -> (t, string) result
   val to_yojson : t -> Yojson.Safe.t

--- a/lib/metadata.mli
+++ b/lib/metadata.mli
@@ -35,7 +35,9 @@ module ArrayMetadata : sig
 
   val create :
     ?sep:Extensions.separator ->
-    ?codecs:Codecs.Chain.t  ->
+    ?codecs:Codecs.Chain.t ->
+    ?dimension_names:string option list ->
+    ?attributes:Yojson.Safe.t ->
     shape:int array ->
     ('a, 'b) Bigarray.kind ->
     'a ->
@@ -50,13 +52,10 @@ module ArrayMetadata : sig
 
   val decode : string -> (t, [> error]) result
   (** [decode s] decodes a bytes string [s] into a {!ArrayMetadata.t}
-      type, and returns an {!error} error if the decoding process fails. *)
+      type, and returns an error if the decoding process fails. *)
 
   val shape : t -> int array
   (** [shape t] returns the shape of the zarr array represented by metadata type [t]. *)
-
-  val fill_value : t -> FillValue.t
-  (** [fill_value t] returns the fill value of the zarra array represented by [t]. *)
 
   val ndim : t -> int
   (** [ndim t] returns the number of dimension in a Zarr array. *)
@@ -64,26 +63,25 @@ module ArrayMetadata : sig
   val chunk_shape : t -> int array
   (** [chunk_shape t] returns the shape a chunk in this zarr array. *)
 
-  val dtype : t -> Extensions.Datatype.t
-  (** [dtype t] returns the data type as specified in the array metadata. *)
+  val data_type : t -> string
+  (** [data_type t] returns the data type as specified in the array metadata.*)
 
   val is_valid_kind : t -> ('a, 'b) Bigarray.kind -> bool
-  (** [is_valid_kind t kind] checks if [kind] is a valid {!Bigarray.kind} that
+  (** [is_valid_kind t kind] checks if [kind] is a valid Bigarray kind that
       matches the data type of the zarr array represented by this metadata type. *)
 
   val fillvalue_of_kind : t -> ('a, 'b) Bigarray.kind -> 'a
   (** [fillvalue_of_kind t kind] returns the fill value of uninitialized
-      chunks in this zarr array  given [kind].
+      chunks in this zarr array  given [kind]. Raises Failure if the kind
+      is not compatible with this array's fill value. *)
 
-      @raises [Failure] if the kind is not compatible with this array's fill value. *)
-
-  val attributes : t -> Yojson.Safe.t option
+  val attributes : t -> Yojson.Safe.t
   (** [attributes t] Returns a Yojson type containing user attributes assigned
       to the zarr array represented by [t]. *)
 
-  val dimension_names : t -> string option list option
-  (** [dimension_name t] returns a list of dimension names, if any are
-      defined in the array's JSON metadata document. *)
+  val dimension_names : t -> string option list
+  (** [dimension_name t] returns a list of dimension names. If none are
+      defined then an empty list is returned. *)
 
   val codecs : t -> Codecs.Chain.t
   (** [codecs t] Returns a type representing the chain of codecs applied
@@ -105,20 +103,25 @@ module ArrayMetadata : sig
   val chunk_key : t -> int array -> string
   (** [chunk_key t idx] returns a key encoding of a the chunk index [idx]. *)
 
-  val update_attributes : Yojson.Safe.t -> t -> t
-  (** [update_attributes json t] returns a new metadata type with an updated
+  val update_attributes : t -> Yojson.Safe.t -> t
+  (** [update_attributes t json] returns a new metadata type with an updated
       attribute field containing contents in [json] *)
 
   val update_shape : t -> int array -> t
   (** [update_shape t new_shp] returns a new metadata type containing
       shape [new_shp]. *)
 
+  val equal : t -> t -> bool
+  (** [equal a b] returns true if [a] [b] are equal array metadata documents
+      and false otherwise. *)
+
   val of_yojson : Yojson.Safe.t -> (t, string) result
-  (** [of_yojson json] converts a {!Yojson.Safe.t} object into a {!ArrayMetadata.t}
+  (** [of_yojson json] converts a [Yojson.Safe.t] object into a {!ArrayMetadata.t}
      and returns an error message upon failure. *)
 
   val to_yojson : t -> Yojson.Safe.t
-  (** [to_yojson t] serializes an array metadata type into a {!Yojson.Safe.t} object. *)
+  (** [to_yojson t] serializes an array metadata type into a [Yojson.Safe.t]
+      object. *)
 end
 
 module GroupMetadata : sig
@@ -135,19 +138,19 @@ module GroupMetadata : sig
   (** [encode t] returns a byte string representing a JSON Zarr group metadata. *)
 
   val decode : string -> (t, [> error]) result
-  (** [decode s] decodes a bytes string [s] into a {!GroupMetadata.t}
-      type, and returns an {!Metadata.error} error if the decoding process fails. *)
+  (** [decode s] decodes a bytes string [s] into a {!t} type, and returns
+      an error if the decoding process fails. *)
 
   val update_attributes : t -> Yojson.Safe.t -> t
   (** [update_attributes t json] returns a new metadata type with an updated
       attribute field containing contents in [json]. *)
 
   val of_yojson : Yojson.Safe.t -> (t, string) result
-  (** [of_yojson json] converts a {!Yojson.Safe.t} object into a {!GroupMetadata.t}
+  (** [of_yojson json] converts a [Yojson.Safe.t] object into a {!GroupMetadata.t}
      and returns an error message upon failure. *)
 
   val to_yojson : t -> Yojson.Safe.t
-  (** [to_yojson t] serializes a group metadata type into a {!Yojson.Safe.t} object. *)
+  (** [to_yojson t] serializes a group metadata type into a [Yojson.Safe.t] object. *)
 
   val show : t -> string
   (** [show t] pretty-prints the contents of the group metadata type t. *)

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -1,7 +1,9 @@
-type 'a ext_point =
-  {name : string
-  ;configuration : 'a}
-[@@deriving yojson]
+module ExtPoint = struct
+  type 'a t =
+    {name : string
+    ;configuration : 'a}
+  [@@deriving yojson, eq]
+end
 
 type ('a, 'b) array_repr =
   {kind : ('a, 'b) Bigarray.kind

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -1,14 +1,21 @@
-type 'a ext_point =
-  {name : string ; configuration : 'a}
-[@@deriving yojson]
-(** The type representing a JSON extension point metadata configuration. *)
-
 type ('a, 'b) array_repr =
   {kind : ('a, 'b) Bigarray.kind
   ;shape : int array
   ;fill_value : 'a}
 (** The type summarizing the decoded/encoded representation of a Zarr array
     or chunk. *)
+
+module ExtPoint : sig
+  (** The type representing a JSON extension point metadata configuration. *)
+
+  type 'a t = {name : string ; configuration : 'a}
+  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
+  val of_yojson
+    : (Yojson.Safe.t -> ('a, string) result) ->
+      Yojson.Safe.t ->
+      ('a t, string) result
+  val to_yojson : ('a -> Yojson.Safe.t) -> 'a t -> Yojson.Safe.t
+end
 
 module Arraytbl : sig include Hashtbl.S with type key = int array end
 (** A hashtable with integer array keys. *)

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,7 @@
 (test
  (name test_zarr)
- (libraries ounit2 zarr))
+ (libraries
+   zarr
+   ounit2)
+ (preprocess
+   (pps ppx_deriving.show)))

--- a/test/test_metadata.ml
+++ b/test/test_metadata.ml
@@ -13,7 +13,7 @@ let group = [
   | Ok v ->
     assert_equal ~printer:GroupMetadata.show meta v;
   | Error _ ->
-    assert_bool "Decoding well formed metadata should not fail" false);
+    assert_failure "Decoding well formed metadata should not fail");
   assert_bool "" (Result.is_error @@ GroupMetadata.decode {|{"bad_json":0}|});
 
   let meta' =
@@ -25,3 +25,122 @@ let group = [
   in
   assert_equal expected @@ GroupMetadata.encode meta')
 ]
+
+let array = [
+
+"array metadata" >:: (fun _ ->
+  let shape = [|10; 10; 10|] in
+  let chunks = [|5; 2; 6|] in
+  let grid_shape = [|2; 5; 2|] in
+  let dimension_names = [Some "x"; None; Some "z"] in
+
+  let meta =
+    ArrayMetadata.create
+      ~shape ~dimension_names Bigarray.Float32 32.0 chunks
+  in
+  (match ArrayMetadata.encode meta |> ArrayMetadata.decode with
+  | Ok v ->
+    assert_bool "should not fail" @@ ArrayMetadata.equal v meta;
+  | Error _ ->
+    assert_failure "Decoding well formed metadata should not fail");
+
+  assert_bool
+    "" (Result.is_error @@ ArrayMetadata.decode {|{"bad_json":0}|});
+
+  let show_int_array = [%show: int array] in
+  assert_equal
+    ~printer:show_int_array shape @@ ArrayMetadata.shape meta;
+
+  assert_equal
+    ~printer:Codecs.Chain.show
+    Codecs.Chain.default @@
+    ArrayMetadata.codecs meta;
+
+  assert_equal
+    ~printer:string_of_int
+    (Array.length shape)
+    (ArrayMetadata.ndim meta);
+
+  assert_equal
+    ~printer:show_int_array
+    chunks @@
+    ArrayMetadata.chunk_shape meta;
+
+  assert_equal
+    ~printer:show_int_array
+    grid_shape @@
+    ArrayMetadata.grid_shape meta shape;
+
+  let show_int_array_tuple =
+    [%show: int array * int array]
+  in
+  assert_equal
+    ~printer:show_int_array_tuple
+    ([|1; 3; 1|], [|3; 1; 0|]) @@
+    ArrayMetadata.index_coord_pair meta [|8; 7; 6|];
+
+  assert_equal
+    ~printer:show_int_array_tuple
+    ([|2; 5; 1|], [|0; 0; 4|]) @@
+    ArrayMetadata.index_coord_pair meta [|10; 10; 10|];
+
+  assert_equal
+    ~printer:Fun.id
+    "c/2/5/1" @@
+    ArrayMetadata.chunk_key meta [|2; 5; 1|];
+
+  let indices =
+    [[|0; 0; 0|]; [|0; 0; 1|]; [|0; 1; 0|]; [|0; 1; 1|]
+    ;[|1; 0; 0|]; [|1; 0; 1|]; [|1; 1; 0|]; [|1; 1; 1|]]
+  in
+  assert_equal
+    ~printer:[%show: int array list]
+    indices @@
+    ArrayMetadata.chunk_indices meta [|10; 4; 10|];
+
+  assert_equal
+    ~printer:Fun.id
+    {|"float32"|} @@
+    ArrayMetadata.data_type meta;
+
+  assert_equal
+    ~printer:[%show: string option list]
+    dimension_names @@
+    ArrayMetadata.dimension_names meta;
+
+  assert_equal
+    ~printer:Yojson.Safe.show
+    `Null @@
+    ArrayMetadata.attributes meta;
+
+  let attrs = `Assoc [("questions", `String "answer")] in
+  assert_equal
+    ~printer:Yojson.Safe.show
+    attrs
+    ArrayMetadata.(attributes @@ update_attributes meta attrs);
+
+  let new_shape = [|20; 10; 6|] in
+  assert_equal
+    ~printer:show_int_array
+    new_shape @@
+    ArrayMetadata.(shape @@ update_shape meta new_shape);
+
+  assert_bool
+    "" @@ ArrayMetadata.is_valid_kind meta Bigarray.Float32;
+
+  assert_bool
+    "Float32 is the only valid kind for this metadata"
+    (not @@ ArrayMetadata.is_valid_kind meta Bigarray.Int8_signed);
+
+  assert_equal
+    ~printer:string_of_float
+    32. @@
+    ArrayMetadata.fillvalue_of_kind meta Bigarray.Float32;
+
+  assert_raises
+    ~msg:"Wrong kind used to extract fill value."
+    (Failure "kind is not compatible with node's fill value.")
+    (fun () -> ArrayMetadata.fillvalue_of_kind meta Bigarray.Complex32))
+]
+
+let tests = group @ array

--- a/test/test_zarr.ml
+++ b/test/test_zarr.ml
@@ -5,6 +5,6 @@ let () =
   let suite = "Run All tests" >:::
       Test_node.tests @
       Test_indexing.tests @
-      Test_metadata.group
+      Test_metadata.tests
   in
   run_test_tt_main suite


### PR DESCRIPTION
This also improves the correctness of serializing/deserializing the
ArrayMetadata type. it also removes unnecessary functions exposed in
the module signature.
- Add equal functions for comparing various type values.
- extends the `ext_point` type into a module with minimum
functions for serialization and comparison; namely `of_yojson`, `to_yojson` and `equal`.