### PR TITLE
Split `Node.t` into `ArrayNode.t` and `GroupNode.t`.

### DIFF
--- a/lib/node.ml
+++ b/lib/node.ml
@@ -1,8 +1,3 @@
-type t =
-  | Root
-  | Cons of t * string
-  [@@deriving show]
-
 type error =
   [ `Node_invariant of string ]
 
@@ -13,77 +8,170 @@ let rep_ok name =
   not (String.for_all (Char.equal '.') name) &&
   not (String.starts_with ~prefix:"__" name)
 
-let root = Root 
+module rec GroupNode : sig
+  type t
+  val root : t
+  val create : t -> string -> (t, [> error]) result
+  val ( / ) : t -> string -> (t, [> error]) result
+  val of_path : string -> (t, [> error]) result
+  val to_path : t -> string
+  val name : t -> string
+  val parent : t -> t option
+  val ( = ) : t -> t -> bool
+  val ancestors : t -> t list
+  val to_key : t -> string
+  val to_prefix : t -> string
+  val to_metakey : t -> string
+  val is_child_group : t -> t -> bool
+  val show : t -> string
+  val pp : Format.formatter -> t -> unit
+end = struct
+  type t =
+    | Root
+    | Cons of t * string
+    [@@deriving show]
 
-let create parent name =
-  if rep_ok name then
-    Result.ok @@ Cons (parent, name)
-  else
-    Error (`Node_invariant name)
+  let create parent name =
+    if rep_ok name then
+      Result.ok @@ Cons (parent, name)
+    else
+      Error (`Node_invariant name)
 
-let ( / ) = create
+  let ( / ) = create
 
-let of_path = function
-  | "/" -> Ok Root
-  | str ->
-    if not String.(starts_with ~prefix:"/" str) then
-      Result.error @@
-      `Node_invariant "path should start with a /"
-    else if String.ends_with ~suffix:"/" str then
-      Result.error @@
-      `Node_invariant "path should not end with a /"
-    else 
-      let open Util.Result_syntax in
-      List.fold_left
-        (fun acc n -> acc >>= fun p -> create p n)
-        (Ok Root) (List.tl @@ String.split_on_char '/' str)
+  let root = Root 
 
-let name = function
-  | Root -> ""
-  | Cons (_, n) -> n
+  let of_path = function
+    | "/" -> Ok Root
+    | str ->
+      if not String.(starts_with ~prefix:"/" str) then
+        Result.error @@
+        `Node_invariant "path should start with a /"
+      else if String.ends_with ~suffix:"/" str then
+        Result.error @@
+        `Node_invariant "path should not end with a /"
+      else 
+        let open Util.Result_syntax in
+        List.fold_left
+          (fun acc n -> acc >>= fun p -> create p n)
+          (Ok Root) (List.tl @@ String.split_on_char '/' str)
 
-let parent = function
-  | Root -> None
-  | Cons (parent, _) -> Some parent
+  let name = function
+    | Root -> ""
+    | Cons (_, n) -> n
 
-let rec fold f acc = function
-  | Root -> f acc Root
-  | Cons (parent, _) as p ->
-    fold f (f acc p) parent
+  let parent = function
+    | Root -> None
+    | Cons (parent, _) -> Some parent
 
-let rec ( = ) x y =
-  match x, y with
-  | Root, Root -> true
-  | Root, Cons _ | Cons _, Root -> false
-  | Cons (p, n), Cons (q, m) -> ( = ) p q && String.equal n m
+  let rec ( = ) x y =
+    match x, y with
+    | Root, Root -> true
+    | Root, Cons _ | Cons _, Root -> false
+    | Cons (p, n), Cons (q, m) -> ( = ) p q && String.equal n m
 
-let to_path = function
-  | Root -> "/"
-  | p ->
+  let rec fold f acc = function
+    | Root -> f acc Root
+    | Cons (parent, _) as p ->
+      fold f (f acc p) parent
+
+  let to_path = function
+    | Root -> "/"
+    | p ->
+      fold (fun acc -> function
+        | Root -> acc
+        | Cons (_, n) -> "/" :: n :: acc) [] p
+      |> String.concat ""
+
+  let ancestors p =
     fold (fun acc -> function
       | Root -> acc
-      | Cons (_, n) -> "/" :: n :: acc) [] p
-    |> String.concat ""
+      | Cons (parent, _) -> parent :: acc) [] p
 
-let ancestors p =
-  fold (fun acc -> function
-    | Root -> acc
-    | Cons (parent, _) -> parent :: acc) [] p
+  let to_key p =
+    let str = to_path p in
+    String.(length str - 1 |> sub str 1)
 
-let to_key p =
-  let str = to_path p in
-  String.(length str - 1 |> sub str 1)
+  let to_prefix = function
+    | Root -> ""
+    | p -> to_key p ^ "/"
 
-let to_prefix = function
-  | Root -> ""
-  | p -> to_key p ^ "/"
+  let to_metakey p =
+    to_prefix p ^ "zarr.json"
 
-let to_metakey p =
-  to_prefix p ^ "zarr.json"
+  let is_child_group x y =
+    match x, y with
+    | _, Root -> false
+    | v, Cons (parent, _) -> parent = v
 
-let is_parent x y =
-  match x, y with
-  | Root, _ -> false
-  | Cons (parent, _), v -> parent = v
+  let show n = to_path n
+end
 
-let show n = to_path n
+and ArrayNode : sig
+  type t
+  val create : GroupNode.t -> string -> (t, [> error]) result
+  val ( / ) : GroupNode.t -> string -> (t, [> error]) result
+  val of_path : string -> (t, [> error]) result
+  val to_path : t -> string
+  val name : t -> string
+  val parent : t -> GroupNode.t
+  val ( = ) : t -> t -> bool
+  val ancestors : t -> GroupNode.t list
+  val is_parent : t -> GroupNode.t -> bool
+  val to_key : t -> string
+  val to_metakey : t -> string
+  val show : t -> string
+  val pp : Format.formatter -> t -> unit
+end = struct
+  type t = {parent : GroupNode.t; name :  string} [@@deriving show]
+
+  let create parent name =
+    if rep_ok name then
+      Result.ok @@ {parent; name}
+    else
+      Error (`Node_invariant name)
+
+  let ( / ) = create
+
+  let of_path p =
+    match GroupNode.of_path p with
+    | Error e -> Error e
+    | Ok g ->
+      match GroupNode.parent g with
+      | Some parent ->
+        Ok {parent; name = GroupNode.name g}
+      | None ->
+        Result.error @@
+        `Node_invariant "Cannot create an array node from a root path"
+      
+  let ( = )
+    {parent = p; name = n}
+    {parent = q; name = m} = p = q && n = m
+
+  let name = function
+    | {parent = _; name} -> name
+
+  let parent = function
+    | {parent; _} -> parent
+
+  let to_path = function
+    | {parent = p; name} -> 
+      if GroupNode.(p = root) then
+        "/" ^ name
+      else
+        GroupNode.to_path p ^ "/" ^ name
+  
+  let ancestors = function
+    | {parent; _} -> parent :: GroupNode.ancestors parent
+
+  let is_parent x y =
+    match x with
+    | {parent = p; _} -> GroupNode.(p = y)
+
+  let to_key = function
+    | {parent; name} -> GroupNode.to_prefix parent ^ name
+
+  let to_metakey p = to_key p ^ "/zarr.json"
+  
+  let show = to_path
+end

--- a/lib/node.mli
+++ b/lib/node.mli
@@ -10,67 +10,118 @@
     - must not be a string composed only of period characters, e.g. "." or "..".
     - must not start with the reserved prefix "__".*)
 
-type t
-(** The type of a node. *)
-
 type error =
   [ `Node_invariant of string ]
-(** The error type for operations on the {!Node.t} type. It is returned by
-    functions that create a {!Node.t} type when one or more of a Node's
-    invariants are not satisfied as defined in the Zarr V3 specification.*)
+(** The error type for operations on node types. It is returned by
+    functions that create an array or group node type when one or more of a
+    node's invariants are not satisfied as defined in the Zarr V3 specification.*)
 
-val root : t
-(** Returns the root node *)
+module GroupNode : sig
+  type t
+  (** The type of a Group node. *)
 
-val create : t -> string -> (t, [> error]) result
-(** [create p n] returns a node with parent [p] and name [n]
-    or an error of type {!error} if this operation fails. *)
+  val root : t
+  (** creates the root node *)
 
-val ( / ) : t -> string -> (t, [> error]) result
-(** The infix operator alias of {!Node.create} *)
+  val create : t -> string -> (t, [> error]) result
+  (** [create p n] returns a group node with parent [p] and name [n]
+      or an error if this operation fails. *)
 
-val of_path : string -> (t, [> error]) result
-(** [of_path s] returns a node from string [s] or an error of
-    type {!error} upon failure. *)
+  val ( / ) : t -> string -> (t, [> error]) result
+  (** The infix operator alias of {!create} *)
 
-val to_path : t -> string
-(** [to_path n] returns node [n] as a string path. *)
+  val of_path : string -> (t, [> error]) result
+  (** [of_path s] returns a node from string [s] or an error upon failure. *)
 
-val name : t -> string
-(** [name n] returns the name of node [n]. The root node does not have a
-    name and thus the empty string [""] is returned if [n] is a root node. *)
+  val to_path : t -> string
+  (** [to_path n] returns node [n] as a string path. *)
 
-val parent : t -> t option
-(** [parent n] returns [Some p] where [p] is the parent node of [n]
-    of [None] if node [n] is the root node. *)
+  val name : t -> string
+  (** [name n] returns the name of node [n]. The root node does not have a
+      name and thus the empty string [""] is returned if [n] is a root node. *)
 
-val ( = ) : t -> t -> bool
-(** [x = y] returns [true] if nodes [x] and [y] are equal,
-    and [false] otherwise. *)
+  val parent : t -> t option
+  (** [parent n] returns [Some p] where [p] is the parent node of [n]
+      of [None] if node [n] is the root node. *)
 
-val ancestors : t -> t list
-(** [ancestors n] returns ancestor nodes of [n] including the root node.
-    The root node has no ancestors, thus this returns the empty list
-    is called on a root node. *)
+  val ( = ) : t -> t -> bool
+  (** [x = y] returns [true] if nodes [x] and [y] are equal,
+      and [false] otherwise. *)
 
-val to_key : t -> string
-(** [to_key n] converts a node's path to a key, as defined in the Zarr V3
-    specification. *)
+  val ancestors : t -> t list
+  (** [ancestors n] returns ancestor nodes of [n] including the root node.
+      The root node has no ancestors, thus this returns the empty list
+      is called on a root node. *)
 
-val to_prefix : t -> string
-(** [to_prefix n] converts a node's path to a prefix key, as defined
-    in the Zarr V3 specification. *)
+  val to_key : t -> string
+  (** [to_key n] converts a node's path to a key, as defined in the Zarr V3
+      specification. *)
 
-val to_metakey : t -> string
-(** [to_prefix n] returns the metadata key associated with node [n],
-    as defined in the Zarr V3 specification. *)
+  val to_prefix : t -> string
+  (** [to_prefix n] converts a node's path to a prefix key, as defined
+      in the Zarr V3 specification. *)
 
-val is_parent : t -> t -> bool
-(** [is_parent m n] Tests if node [n] is a the immediate parent of
-    node [m]. Returns [true] when the test passes and [false] otherwise. *)
+  val to_metakey : t -> string
+  (** [to_prefix n] returns the metadata key associated with node [n],
+      as defined in the Zarr V3 specification. *)
 
-val show : t -> string
-(** [show n] returns a string representation of a node type. *)
+  val is_child_group : t -> t -> bool
+  (** [is_child_group m n] Tests if group node [m] is a the immediate parent of
+      group node [n]. Returns [true] when the test passes and [false] otherwise. *)
 
-val pp : Format.formatter -> t -> unit
-(** [pp fmt t] pretty prints a node type value. *)
+  val show : t -> string
+  (** [show n] returns a string representation of a node type. *)
+
+  val pp : Format.formatter -> t -> unit
+  (** [pp fmt t] pretty prints a node type value. *)
+end
+
+module ArrayNode : sig
+  type t
+  (** The type of an array node. *)
+
+  val create : GroupNode.t -> string -> (t, [> error]) result
+  (** [create p n] returns an array node with parent [p] and name [n]
+      or an error if this operation fails. *)
+
+  val ( / ) : GroupNode.t -> string -> (t, [> error]) result
+  (** The infix operator alias of {!ArrayNode.create} *)
+
+  val of_path : string -> (t, [> error]) result
+  (** [of_path s] returns an array node from string [s] or an error
+      upon failure. *)
+
+  val to_path : t -> string
+  (** [to_path n] returns array node [n] as a string path. *)
+
+  val name : t -> string
+  (** [name n] returns the name of array node [n]. *)
+
+  val parent : t -> GroupNode.t
+  (** [parent n] returns parent group node of [n].*)
+
+  val ( = ) : t -> t -> bool
+  (** [x = y] returns [true] if nodes [x] and [y] are equal,
+      and [false] otherwise. *)
+
+  val ancestors : t -> GroupNode.t list
+  (** [ancestors n] returns ancestor group nodes of [n]. *)
+
+  val is_parent : t -> GroupNode.t -> bool
+  (** [is_parent n g] returns [true] if group node [g] is the immediate
+      parent of array node [n] and [false] otherwise. *)
+
+  val to_key : t -> string
+  (** [to_key n] converts a node's path to a key, as defined in the Zarr V3
+      specification. *)
+
+  val to_metakey : t -> string
+  (** [to_prefix n] returns the metadata key associated with node [n],
+      as defined in the Zarr V3 specification. *)
+
+  val show : t -> string
+  (** [show n] returns a string representation of a node type. *)
+
+  val pp : Format.formatter -> t -> unit
+  (** [pp fmt t] pretty prints a node type value. *)
+end

--- a/test/test_node.ml
+++ b/test/test_node.ml
@@ -1,103 +1,170 @@
 open OUnit2
-open Zarr
+open Zarr.Node
 
-let creation_failure = "Creation of node should not fail." 
 
-let tests = [
+let group_node = [
+"group node tests" >:: (fun _ ->
+  let creation_failure = "Creation of group node should not fail." in
+  let r = GroupNode.(root / "somename") in
+  assert_bool creation_failure @@ Result.is_ok r;
 
-"creation" >:: (fun _ ->
-  let n = Node.(root / "somename") in
-  assert_bool creation_failure @@ Result.is_ok n;
-  let p = Result.get_ok n in
-  let msg = "Creation of node should not succeed." in
+  (* test node invariants *)
+  let n = Result.get_ok r in
+  let msg = "Creation of group node should not succeed." in
   List.iter
     (fun x -> assert_bool msg @@ Result.is_error x) @@
-    List.map (Node.create p) [""; "na/me"; "...."; "__name"])
-;
-"creation from path string" >:: (fun _ ->
-  let n = Node.of_path "/" in
-  assert_bool creation_failure @@ Result.is_ok n;
+    List.map (GroupNode.create n) [""; "na/me"; "...."; "__name"];
+
+  (* creation from string path *)
+  let r = GroupNode.of_path "/" in
+  assert_bool creation_failure @@ Result.is_ok r;
   assert_equal
-    ~printer:Node.show Node.root @@ Result.get_ok n;
-  let msg = "Creation of node should not succeed" in
+    ~printer:GroupNode.show GroupNode.root @@ Result.get_ok r;
   List.iter
     (fun x -> assert_bool msg @@ Result.is_error x) @@
     List.map
-      Node.of_path @@
-      [""; "na/meas"; "/some/..."; "/root/__name"; "/sd/"])
-;
-"exploratory functions" >:: (fun _ ->
+      GroupNode.of_path @@
+      [""; "na/meas"; "/some/..."; "/root/__name"; "/sd/"];
+
+  (* node name tests *)
   let s = "/some/dir/moredirs/path/pname" in
-  let n = Node.of_path s |> Result.get_ok in
-  assert_equal "pname" @@ Node.name n;
-  assert_equal "" @@ Node.name Node.root;
+  let n = GroupNode.of_path s |> Result.get_ok in
+  assert_equal "pname" @@ GroupNode.name n;
+  assert_equal "" @@ GroupNode.name GroupNode.root;
 
-  assert_equal None @@ Node.parent Node.root;
-  match Node.parent n with
+  (* parent tests *)
+  assert_equal None @@ GroupNode.parent GroupNode.root;
+  match GroupNode.parent n with
   | None ->
-    assert_failure
-      "A non-root node must have a parent.";
+    assert_failure "A non-root node must have a parent.";
   | Some p ->
-    assert_equal
-      "/some/dir/moredirs/path" @@ Node.show p;
+    assert_equal "/some/dir/moredirs/path" @@ GroupNode.show p;
 
-  assert_equal ~printer:Node.show Node.root Node.root;
+  (* equality tests *)
+  assert_equal ~printer:GroupNode.show GroupNode.root GroupNode.root;
   assert_bool
     "root node cannot be equal to its child" @@
-    not Node.(root = n);
+    not GroupNode.(root = n);
   assert_bool
     "non-root node cannot have root as child" @@
-    not Node.(n = root);
+    not GroupNode.(n = root);
 
-  assert_equal [] @@ Node.ancestors Node.root;
+  (* ancestory tests *)
+  assert_equal [] @@ GroupNode.ancestors GroupNode.root;
   assert_equal
     ~printer:[%show: string list]
     ["/"; "/some"; "/some/dir"; "/some/dir/moredirs"
     ;"/some/dir/moredirs/path"]
-    (Node.ancestors n |> List.map Node.show);
-
-  let p = Node.parent n |> Option.get in
-  assert_equal
-    ~printer:string_of_bool
-    true @@
-    Node.is_parent n p;
-  assert_equal
-    ~printer:string_of_bool
-    false @@
-    Node.is_parent Node.root n;
-  assert_equal
-    ~printer:string_of_bool
-    false @@
-    Node.is_parent Node.root Node.root;
-
-  let exp_parents = Node.ancestors n in
+    (GroupNode.ancestors n |> List.map GroupNode.show);
+  let exp_parents = GroupNode.ancestors n in
   let r, l = List.fold_left_map
     (fun acc _ ->
-      match Node.parent acc with
+      match GroupNode.parent acc with
       | Some acc' -> acc', acc'
       | None -> acc, acc) n exp_parents
   in
   assert_equal
-    ~printer:[%show: Node.t list]
+    ~printer:[%show: GroupNode.t list]
     exp_parents @@
     List.rev l;
-  assert_equal ~printer:Node.show r Node.root;
+  assert_equal ~printer:GroupNode.show r GroupNode.root;
 
+  (* child node tests *)
+  let p = GroupNode.parent n |> Option.get in
   assert_equal
-    ~printer:Fun.id "" @@ Node.to_key Node.root;
+    ~printer:string_of_bool
+    true @@
+    GroupNode.is_child_group p n;
+  assert_equal
+    ~printer:string_of_bool
+    false @@
+    GroupNode.is_child_group n GroupNode.root;
+  assert_equal
+    ~printer:string_of_bool
+    false @@
+    GroupNode.is_child_group GroupNode.root GroupNode.root;
+
+  (* stringify tests *)
+  assert_equal
+    ~printer:Fun.id "" @@ GroupNode.to_key GroupNode.root;
 
   assert_equal
     ~printer:Fun.id
     "some/dir/moredirs/path/pname" @@
-    Node.to_key n;
+    GroupNode.to_key n;
 
   assert_equal
     ~printer:Fun.id
     "zarr.json" @@
-    Node.to_metakey Node.root;
+    GroupNode.to_metakey GroupNode.root;
 
   assert_equal
     ~printer:Fun.id
     ("some/dir/moredirs/path/pname/zarr.json") @@
-    Node.to_metakey n)
+    GroupNode.to_metakey n)
 ]
+
+let array_node = [
+"array node tests" >:: (fun _ ->
+  let r = ArrayNode.(GroupNode.root / "somename") in
+  assert_bool "" @@ Result.is_ok r;
+
+  (* test node invariants *)
+  let msg = "Creation of group node should not succeed." in
+  List.iter
+    (fun x -> assert_bool msg @@ Result.is_error x) @@
+    List.map
+      (ArrayNode.create GroupNode.root)
+      [""; "na/me"; "...."; "__name"];
+
+  (* creation from string path *)
+  let msg = "creating an array node from an illformed path is impossible" in
+  List.iter
+    (fun x -> assert_bool msg @@ Result.is_error x) @@
+    List.map
+      ArrayNode.of_path @@
+      ["/"; ""; "na/meas"; "/some/..."; "/root/__name"; "/sd/"];
+
+  (* node name tests *)
+  let s = "/some/dir/moredirs/path/pname" in
+  let n = ArrayNode.of_path s |> Result.get_ok in
+  assert_equal "pname" @@ ArrayNode.name n;
+  assert_equal ~printer:Fun.id s @@ ArrayNode.to_path n;
+
+  (* parent tests *)
+  assert_equal
+    ~printer:GroupNode.show
+    GroupNode.root @@
+    ArrayNode.parent (ArrayNode.of_path "/nodename" |> Result.get_ok);
+
+  (* equality tests *)
+  assert_equal
+    true @@ ArrayNode.(n = (ArrayNode.of_path s |> Result.get_ok));
+  assert_equal
+    false @@
+    ArrayNode.(n = Result.get_ok @@ ArrayNode.of_path (s ^ "/more"));
+
+  (* ancestory tests *)
+  assert_equal
+    ~printer:[%show: string list]
+    ["/"; "/some"; "/some/dir"; "/some/dir/moredirs"
+    ;"/some/dir/moredirs/path"]
+    (ArrayNode.ancestors n
+      |> List.map GroupNode.show
+      |> List.fast_sort String.compare);
+  let m = ArrayNode.of_path "/some" |> Result.get_ok in
+  assert_equal true @@ ArrayNode.is_parent m GroupNode.root;
+
+  (* stringify tests *)
+  assert_equal
+    ~printer:Fun.id
+    "some/dir/moredirs/path/pname" @@
+    ArrayNode.to_key n;
+
+  assert_equal
+    ~printer:Fun.id
+    ("some/dir/moredirs/path/pname/zarr.json") @@
+    ArrayNode.to_metakey n)
+]
+
+let tests = group_node @ array_node


### PR DESCRIPTION
This reduces the number of runtime checks to determine the kind of node when calling storage functions.