### PR TITLE
Remove unneeded json (de-)serialization code generators for codecs.

### DIFF
--- a/lib/codecs/array_to_array.ml
+++ b/lib/codecs/array_to_array.ml
@@ -11,19 +11,31 @@ type error =
 
 (* https://zarr-specs.readthedocs.io/en/latest/v3/codecs/transpose/v1.0.html *)
 module TransposeCodec = struct
-  type config = {order : int array} [@@deriving yojson]
-  type transpose = config Util.ExtPoint.t  [@@deriving yojson]
-
   let compute_encoded_size input_size = input_size
 
   let compute_encoded_representation
     : type a b.
       int array ->
       (a, b) Util.array_repr ->
-      (a, b) Util.array_repr
+      ((a, b) Util.array_repr, [> error]) result
     = fun t decoded ->
-      {decoded with
-        shape = Array.map (fun x -> decoded.shape.(x)) t}
+      try
+        let shape = Array.map (fun x -> decoded.shape.(x)) t in
+        (* transpose codec should not lead to change in array size*)
+        if Util.prod shape <> Util.prod decoded.shape then
+          let msg =
+            "transpose order leads to a change in encoded
+            representation size, which is prohibited." in
+          Result.error @@ `Invalid_transpose_order (t, msg)
+        else
+          Ok {decoded with shape}
+      with
+      | Invalid_argument _ ->
+        let msg =
+          "transpose order max element is larger than
+          the decoded representation dimensionality." in
+        Result.error @@ `Invalid_transpose_order (t, msg)
+
 
   let parse_order o =
     if Array.length o = 0 then
@@ -68,18 +80,37 @@ module TransposeCodec = struct
   let decode o x =
     let inv_order = Array.(make (length o) 0) in
     Array.iteri (fun i x -> inv_order.(x) <- i) o;
-    try Ok (Ndarray.transpose ~axis:inv_order x) with
-    | Failure s -> Error (`Invalid_transpose_order (o, s))
+    Ok (Ndarray.transpose ~axis:inv_order x)
 
   let to_yojson order =
-    transpose_to_yojson
-      {name = "transpose"; configuration = {order}}
+    let o = 
+      `List (Array.to_list @@ Array.map (fun x -> `Int x) order) in
+    `Assoc
+    [("name", `String "transpose")
+    ;("configuration", `Assoc ["order", o])]
 
   let of_yojson x =
     let open Util.Result_syntax in
-    transpose_of_yojson x >>= fun trans ->
-    parse_order trans.configuration.order
-    >>? fun (`Invalid_transpose_order _) -> "Invalid transpose order"
+    match Yojson.Safe.Util.(member "configuration" x |> to_assoc) with
+    | [("order", `List o)] ->
+      if List.length o = 0 then
+        Error "transpose order must not be empty."
+      else
+        List.fold_right
+          (fun a acc ->
+            acc >>= fun k ->
+            match a with
+            | `Int i
+                when i >= 0  (* non-negative *)
+                && not @@ List.mem i k (* unique *) ->
+              Ok (i :: k)
+            | _ ->
+              let msg =
+                "transpose order must only
+                contain positive integers and unique values."
+              in Error msg) o (Ok [])
+        >>| fun o' -> Transpose (Array.of_list o')
+    | _ -> Error "Invalid transpose configuration."
 end
 
 module ArrayToArray = struct
@@ -93,7 +124,7 @@ module ArrayToArray = struct
     : type a b.
       array_to_array ->
       (a, b) Util.array_repr ->
-      (a, b) Util.array_repr
+      ((a, b) Util.array_repr, [> error]) result
     = fun t repr ->
     match t with
     | Transpose o ->

--- a/lib/codecs/array_to_array.mli
+++ b/lib/codecs/array_to_array.mli
@@ -20,7 +20,7 @@ module ArrayToArray : sig
   val compute_encoded_representation
     : array_to_array ->
       ('a, 'b) Util.array_repr ->
-      ('a, 'b) Util.array_repr
+      (('a, 'b) Util.array_repr, [> error]) result
   val encode
     : array_to_array ->
       ('a, 'b) Ndarray.t ->

--- a/lib/codecs/array_to_bytes.ml
+++ b/lib/codecs/array_to_bytes.ml
@@ -488,8 +488,8 @@ end = struct
       List.fold_right (fun a acc ->
         acc >>= fun k ->
         match a with
-        | `Int i -> Ok (i :: k)
-        | _ -> Error "chunk_shape must only contain integers.")
+        | `Int i when i > 0 -> Ok (i :: k)
+        | _ -> Error "chunk_shape must only contain positive integers.")
         (Yojson.Safe.Util.to_list x) (Ok []))
     >>= fun l'->
     let chunk_shape = Array.of_list l' in


### PR DESCRIPTION
- Gzip and CRC32c codecs have a simple configuration that does not need
code generators to implement correct json deserialization/serialization.
- This allows us to do more thorough parsing of the configuration
like checking for emptiness, value max and signedness of order
elements when reading from a JSON document.
- This manually implements the (de)serializatioin functions since
they are not complicated. This allows for better error reporting
messages.
- Also improve test coverage of codecs to reflect correctness of implementations.