### PR TITLE
Implement `{to/of}_yojson` functions for Metadata types.

### DIFF
--- a/lib/codecs/array_to_bytes.mli
+++ b/lib/codecs/array_to_bytes.mli
@@ -24,11 +24,12 @@ val pp_chain : Format.formatter -> chain -> unit
 val show_chain : chain -> string
 
 type error =
-  [ `Bytes_encode_error of string
-  | `Bytes_decode_error of string
-  | `Sharding_shape_mismatch of int array * int array * string
+  [ Extensions.error
   | Array_to_array.error
-  | Bytes_to_bytes.error ]
+  | Bytes_to_bytes.error
+  | `Bytes_encode_error of string
+  | `Bytes_decode_error of string
+  | `Sharding_shape_mismatch of int array * int array * string ]
 
 module ArrayToBytes : sig
   val parse

--- a/lib/codecs/codecs.ml
+++ b/lib/codecs/codecs.ml
@@ -55,14 +55,14 @@ module Chain = struct
       (fun c acc -> acc >>= ArrayToArray.decode c)
       t.a2a (ArrayToBytes.decode y repr' t.a2b)
 
-  let equal x y =
+  let ( = ) x y =
     x.a2a = y.a2a && x.a2b = y.a2b && x.b2b = y.b2b
 
   let to_yojson t =
-    [%to_yojson: Yojson.Safe.t list] @@ 
-    List.map ArrayToArray.to_yojson t.a2a @
-    (ArrayToBytes.to_yojson t.a2b) ::
-    List.map BytesToBytes.to_yojson t.b2b
+    `List
+      (List.map ArrayToArray.to_yojson t.a2a @
+      (ArrayToBytes.to_yojson t.a2b) ::
+      List.map BytesToBytes.to_yojson t.b2b)
 
   let of_yojson x =
     let filter_partition f encoded =

--- a/lib/codecs/codecs.mli
+++ b/lib/codecs/codecs.mli
@@ -53,7 +53,7 @@ module Chain : sig
       string ->
       (('a, 'b) Ndarray.t, [> error]) result
 
-  val equal : t -> t -> bool
+  val ( = ) : t -> t -> bool
 
   val of_yojson : Yojson.Safe.t -> (t, string) result
 

--- a/lib/dune
+++ b/lib/dune
@@ -3,7 +3,6 @@
  (public_name zarr)
  (libraries
    yojson
-   ppx_deriving_yojson.runtime
    ezgzip
    owl
    stdint
@@ -12,9 +11,7 @@
    (:standard -O3))
  (preprocess
    (pps
-     ppx_deriving.eq
-     ppx_deriving.show
-     ppx_deriving_yojson))
+     ppx_deriving.show))
  (instrumentation
    (backend bisect_ppx)))
 

--- a/lib/extensions.mli
+++ b/lib/extensions.mli
@@ -1,11 +1,19 @@
+type grid_info =
+  {msg : string
+  ;chunk_shape : int array
+  ;array_shape : int array}
+
+type error =
+  [ `Grid of grid_info ]
+
 module RegularGrid : sig
   type t
-  val create : int array -> t
+  val create : array_shape:int array -> int array -> (t, [> error]) result
   val chunk_shape : t -> int array
   val grid_shape : t -> int array -> int array
   val indices : t -> int array -> int array list
   val index_coord_pair : t -> int array -> int array * int array
-  val equal : t -> t -> bool
+  val ( = ) : t -> t -> bool
   val of_yojson : Yojson.Safe.t -> (t, string) result
   val to_yojson : t -> Yojson.Safe.t
 end
@@ -14,7 +22,7 @@ module ChunkKeyEncoding : sig
   type t
   val create : [< `Slash | `Dot > `Slash ] -> t
   val encode : t -> int array -> string
-  val equal : t -> t -> bool
+  val ( = ) : t -> t -> bool
   val of_yojson : Yojson.Safe.t -> (t, string) result
   val to_yojson : t -> Yojson.Safe.t
 end
@@ -38,7 +46,7 @@ module Datatype : sig
     | Nativeint
   (** A type for the supported data types of a Zarr array. *)
 
-  val equal : t -> t -> bool
+  val ( = ) : t -> t -> bool
   val of_kind : ('a, 'b) Bigarray.kind -> t
   val of_yojson : Yojson.Safe.t -> (t, string) result
   val to_yojson : t -> Yojson.Safe.t

--- a/lib/metadata.ml
+++ b/lib/metadata.ml
@@ -1,5 +1,9 @@
+open Extensions
+open Util.Result_syntax
+
 type error =
-  [ `Json_decode_error of string ]
+  [ Extensions.error
+  | `Json_decode of string ]
 
 module FillValue = struct
   type t =
@@ -15,7 +19,7 @@ module FillValue = struct
     | BFComplex of Complex.t
     | BBComplex of Complex.t
 
-  let equal x y = x = y
+  let ( = ) x y = x = y
 
   let of_kind
   : type a b. (a, b) Bigarray.kind -> a -> t
@@ -36,7 +40,6 @@ module FillValue = struct
     | Bigarray.Nativeint -> Int (Int64.of_nativeint a)
 
   let rec of_yojson x =
-    let open Util.Result_syntax in
     match x with
     | `Bool b -> Ok (Bool b)
     | `Int i -> Result.ok @@ Int (Int64.of_int i)
@@ -103,15 +106,14 @@ module ArrayMetadata = struct
     {zarr_format : int
     ;shape : int array
     ;node_type : string
-    ;data_type : Extensions.Datatype.t
+    ;data_type : Datatype.t
     ;codecs : Codecs.Chain.t
     ;fill_value : FillValue.t
-    ;chunk_grid : Extensions.RegularGrid.t
-    ;chunk_key_encoding : Extensions.ChunkKeyEncoding.t
-    ;attributes : Yojson.Safe.t [@default `Null]
-    ;dimension_names : string option list [@default []]
-    ;storage_transformers : Yojson.Safe.t Util.ExtPoint.t list [@default []]}
-  [@@deriving yojson, eq]
+    ;chunk_grid : RegularGrid.t
+    ;chunk_key_encoding : ChunkKeyEncoding.t
+    ;attributes : Yojson.Safe.t
+    ;dimension_names : string option list
+    ;storage_transformers : Yojson.Safe.t Util.ExtPoint.t list}
 
   let create
     ?(sep=`Slash)
@@ -123,17 +125,156 @@ module ArrayMetadata = struct
     fv
     chunks
     =
+    RegularGrid.create ~array_shape:shape chunks
+    >>| fun chunk_grid ->
     {shape
     ;codecs
-    ;fill_value = FillValue.of_kind kind fv
-    ;data_type = Extensions.Datatype.of_kind kind
-    ;chunk_grid = Extensions.RegularGrid.create chunks
-    ;chunk_key_encoding = Extensions.ChunkKeyEncoding.create sep
-    ;zarr_format = 3
-    ;node_type = "array"
+    ;chunk_grid
     ;attributes
     ;dimension_names
-    ;storage_transformers = []}
+    ;zarr_format = 3
+    ;node_type = "array"
+    ;storage_transformers = []
+    ;fill_value = FillValue.of_kind kind fv
+    ;data_type = Datatype.of_kind kind
+    ;chunk_key_encoding = ChunkKeyEncoding.create sep}
+
+  let to_yojson t =
+    let shape =
+      Array.map (fun x -> `Int x) t.shape |> Array.to_list in
+    let l =
+      [("zarr_format", `Int t.zarr_format)
+      ;("shape", `List shape)
+      ;("node_type", `String t.node_type)
+      ;("data_type", Datatype.to_yojson t.data_type)
+      ;("codecs", Codecs.Chain.to_yojson t.codecs)
+      ;("fill_value", FillValue.to_yojson t.fill_value)
+      ;("chunk_grid", RegularGrid.to_yojson t.chunk_grid)
+      ;("chunk_key_encoding",
+        ChunkKeyEncoding.to_yojson t.chunk_key_encoding)]
+    in
+    let l =
+      match t.attributes with
+      | `Null -> l
+      | x -> l @ [("attributes", x)]
+    in
+    let l =
+      match t.dimension_names with
+      | [] -> l
+      | xs  ->
+        let xs' =
+          List.map (function
+            | Some s -> `String s
+            | None -> `Null) xs
+        in
+        l @ [("dimension_names", `List xs')]
+    in `Assoc l
+
+  let of_yojson x =
+    let open Yojson.Safe.Util in
+    (match member "zarr_format" x with
+    | `Int (3 as i) -> Ok i
+    | `Null -> Error "array metadata must contain a zarr_format field."
+    | _ -> Error "zarr_format field must be the integer 3.")
+    >>= fun zarr_format ->
+
+    (match member "node_type" x with
+    | `String ("array" as a) -> Ok a
+    | `Null -> Error "array metadata must contain a node_type field."
+    | _ -> Error "node_type field must be 'array'.")
+    >>= fun node_type ->
+
+    (* An array can have zero or more dimensions. *)
+    (match member "shape" x with
+    | `List xs ->
+      List.fold_right
+        (fun a acc ->
+            acc >>= fun k ->
+            match a with
+            | `Int i when i > 0 -> Ok (i :: k)
+            | _ ->
+              Result.error @@
+              "shape field list must only contain positive integers.")
+        xs (Ok [])
+        >>| Array.of_list
+     | `Null -> Error "array metadata must contain a shape field."
+     | _ -> Error "shape field must be a list of integers.")
+    >>= fun shape ->
+
+    (match member "data_type" x with
+    | `String _ as c -> Datatype.of_yojson c
+    | `Null -> Error "array metadata must contain a data_type field."
+    | _ -> Error "data_type field must be a string.")
+    >>= fun data_type ->
+
+    (match member "codecs" x with
+    | `List _ as c -> Codecs.Chain.of_yojson c
+    | `Null -> Error "array metadata must contain a codecs field."
+    | _ -> Error "codecs field must be a list of objects.")
+    >>= fun codecs ->
+
+    (match member "fill_value" x with
+    | `Null -> Error "array metadata must contain a fill_value field."
+    | xs -> FillValue.of_yojson xs)
+    >>= fun fill_value ->
+
+    (match member "chunk_grid" x with
+    | `Null -> Error "array metadata must contain a chunk_grid field." 
+    | xs ->
+      RegularGrid.of_yojson xs >>= fun grid -> 
+      RegularGrid.(create ~array_shape:shape @@ chunk_shape grid)
+      >>? fun (`Grid {msg; _}) -> msg)
+    >>= fun chunk_grid ->
+
+    (match member "chunk_key_encoding" x with 
+    | `Null ->
+      Error "array metadata must contain a chunk_key_encoding field." 
+    | xs -> ChunkKeyEncoding.of_yojson xs)
+    >>= fun chunk_key_encoding ->
+
+    (* Optional fields *)
+    let attributes = member "attributes" x in
+
+    (match member "dimension_names" x with
+    | `Null -> Ok []
+    | `List xs ->
+      if List.length xs <> Array.length shape then
+        Result.error
+        "dimension_names length and array dimensionality must be equal."
+      else
+        List.fold_right
+          (fun a acc ->
+              acc >>= fun k ->
+              match a with
+              | `String s -> Ok (Some s :: k)
+              | `Null -> Ok (None :: k)
+              | _ ->
+                let msg =
+                  "dimension_names must contain strings or null values."
+                in Error msg) xs (Ok [])
+    | _ -> Error "dimension_names field must be a list.")
+    >>= fun dimension_names ->
+
+    (match member "storage_transformers" x with
+    | `Null -> Ok []
+    | _ -> Error "storage_transformers field is not yet supported.")
+    >>| fun storage_transformers ->
+
+    {zarr_format; shape; node_type; data_type; codecs; fill_value; chunk_grid
+    ;chunk_key_encoding; attributes; dimension_names; storage_transformers}
+
+  let ( = ) x y =
+    x.zarr_format = y.zarr_format
+    && x.shape = y.shape
+    && x.node_type = y.node_type
+    && Datatype.(x.data_type = y.data_type)
+    && Codecs.Chain.(x.codecs = y.codecs)
+    && FillValue.(x.fill_value = y.fill_value)
+    && RegularGrid.(x.chunk_grid = y.chunk_grid)
+    && ChunkKeyEncoding.(x.chunk_key_encoding = y.chunk_key_encoding)
+    && x.attributes = y.attributes
+    && x.dimension_names = y.dimension_names
+    && x.storage_transformers = y.storage_transformers
 
   let shape t = t.shape
 
@@ -146,27 +287,26 @@ module ArrayMetadata = struct
   let attributes t = t.attributes
 
   let chunk_shape t =
-    Extensions.RegularGrid.chunk_shape t.chunk_grid
+    RegularGrid.chunk_shape t.chunk_grid
 
   let grid_shape t shape =
-    Extensions.RegularGrid.grid_shape t.chunk_grid shape
+    RegularGrid.grid_shape t.chunk_grid shape
 
   let index_coord_pair t coord =
-    Extensions.RegularGrid.index_coord_pair t.chunk_grid coord
+    RegularGrid.index_coord_pair t.chunk_grid coord
 
   let chunk_key t index =
-    Extensions.ChunkKeyEncoding.encode t.chunk_key_encoding index
+    ChunkKeyEncoding.encode t.chunk_key_encoding index
 
   let chunk_indices t shape =
-    Extensions.RegularGrid.indices t.chunk_grid shape
+    RegularGrid.indices t.chunk_grid shape
 
   let encode t =
     Yojson.Safe.to_string @@ to_yojson t
 
   let decode b = 
-    let open Util.Result_syntax in
     of_yojson @@ Yojson.Safe.from_string b >>? fun s ->
-    `Json_decode_error s
+    `Json_decode s
 
   let update_attributes t attrs =
     {t with attributes = attrs}
@@ -177,19 +317,19 @@ module ArrayMetadata = struct
     : type a b. t -> (a, b) Bigarray.kind -> bool
     = fun t kind ->
     match kind, t.data_type with
-    | Bigarray.Char, Extensions.Datatype.Char
-    | Bigarray.Int8_signed, Extensions.Datatype.Int8
-    | Bigarray.Int8_unsigned, Extensions.Datatype.Uint8
-    | Bigarray.Int16_signed, Extensions.Datatype.Int16
-    | Bigarray.Int16_unsigned, Extensions.Datatype.Uint16
-    | Bigarray.Int32, Extensions.Datatype.Int32
-    | Bigarray.Int64, Extensions.Datatype.Int64
-    | Bigarray.Float32, Extensions.Datatype.Float32
-    | Bigarray.Float64, Extensions.Datatype.Float64
-    | Bigarray.Complex32, Extensions.Datatype.Complex32
-    | Bigarray.Complex64, Extensions.Datatype.Complex64
-    | Bigarray.Int, Extensions.Datatype.Int
-    | Bigarray.Nativeint, Extensions.Datatype.Nativeint -> true
+    | Bigarray.Char, Datatype.Char
+    | Bigarray.Int8_signed, Datatype.Int8
+    | Bigarray.Int8_unsigned, Datatype.Uint8
+    | Bigarray.Int16_signed, Datatype.Int16
+    | Bigarray.Int16_unsigned, Datatype.Uint16
+    | Bigarray.Int32, Datatype.Int32
+    | Bigarray.Int64, Datatype.Int64
+    | Bigarray.Float32, Datatype.Float32
+    | Bigarray.Float64, Datatype.Float64
+    | Bigarray.Complex32, Datatype.Complex32
+    | Bigarray.Complex64, Datatype.Complex64
+    | Bigarray.Int, Datatype.Int
+    | Bigarray.Nativeint, Datatype.Nativeint -> true
     | _ -> false
 
   let fillvalue_of_kind
@@ -228,16 +368,44 @@ module GroupMetadata = struct
   type t =
     {zarr_format : int
     ;node_type : string
-    ;attributes : Yojson.Safe.t [@default `Null]}
-  [@@deriving yojson, show]
+    ;attributes : Yojson.Safe.t}
 
   let default =
     {zarr_format = 3; node_type = "group"; attributes = `Null}
 
+  let to_yojson t =
+    let l =
+      [("zarr_format", `Int t.zarr_format)
+      ;("node_type", `String t.node_type)]
+    in
+    let l =
+      match t.attributes with
+      | `Null -> l
+      | x -> l @ [("attributes", x)]
+    in `Assoc l
+
+  let of_yojson x =
+    let open Yojson.Safe.Util in
+    (match member "zarr_format" x with
+    | `Int (3 as i) -> Ok i
+    | `Null -> Error "group metadata must contain a zarr_format field."
+    | _ -> Error "zarr_format field must be the integer 3.")
+    >>= fun zarr_format ->
+    (match member "node_type" x with
+    | `String ("group" as g) -> Ok g
+    | `Null -> Error "group metadata must contain a node_type field."
+    | _ -> Error "node_type field must be 'group.")
+    >>= fun node_type ->
+    let attributes =
+      match member "attributes" x with
+      | `Null -> `Null 
+      | xs -> xs
+    in
+    Ok {zarr_format; node_type; attributes}
+
   let decode s = 
-    let open Util.Result_syntax in
-    of_yojson @@ Yojson.Safe.from_string s >>? fun s ->
-    `Json_decode_error s
+    of_yojson @@ Yojson.Safe.from_string s >>? fun b ->
+    `Json_decode b
 
   let encode t =
     Yojson.Safe.to_string @@ to_yojson t
@@ -246,4 +414,9 @@ module GroupMetadata = struct
     {t with attributes = attrs}
 
   let attributes t = t.attributes
+
+  let show t =
+    Format.sprintf
+      {|"{zarr_format=%d; node_type=%s; attributes=%s}"|}
+      t.zarr_format t.node_type @@ Yojson.Safe.show t.attributes
 end

--- a/lib/metadata.mli
+++ b/lib/metadata.mli
@@ -6,7 +6,8 @@
     [zarr.json] within the prefix of a group or array.*)
 
 type error =
-  [ `Json_decode_error of string ]
+  [ Extensions.error
+  | `Json_decode of string ]
 (** A type for JSON decoding errors. *)
 
 module FillValue : sig
@@ -42,15 +43,15 @@ module ArrayMetadata : sig
     ('a, 'b) Bigarray.kind ->
     'a ->
     int array ->
-    t
+    (t, [> error ]) result
   (** [create ~shape kind fv cshp] Creates a new array metadata document
       with shape [shape], fill value [fv], data type [kind] and chunk shape
-      [cshp]. *)
+      [cshp]. This operation returns an error if chunk shape is invalid. *)
 
   val encode : t -> string
   (** [encode t] returns a byte string representing a JSON Zarr array metadata. *)
 
-  val decode : string -> (t, [> error]) result
+  val decode : string -> (t, [> error ]) result
   (** [decode s] decodes a bytes string [s] into a {!ArrayMetadata.t}
       type, and returns an error if the decoding process fails. *)
 
@@ -108,8 +109,8 @@ module ArrayMetadata : sig
   (** [update_shape t new_shp] returns a new metadata type containing
       shape [new_shp]. *)
 
-  val equal : t -> t -> bool
-  (** [equal a b] returns true if [a] [b] are equal array metadata documents
+  val ( = ) : t -> t -> bool
+  (** [a = b] returns true if [a] [b] are equal array metadata documents
       and false otherwise. *)
 
   val of_yojson : Yojson.Safe.t -> (t, string) result
@@ -134,7 +135,7 @@ module GroupMetadata : sig
   val encode : t -> string
   (** [encode t] returns a byte string representing a JSON Zarr group metadata. *)
 
-  val decode : string -> (t, [> error]) result
+  val decode : string -> (t, [> error ]) result
   (** [decode s] decodes a bytes string [s] into a {!t} type, and returns
       an error if the decoding process fails. *)
 

--- a/lib/storage/storage.ml
+++ b/lib/storage/storage.ml
@@ -49,17 +49,16 @@ module Make (M : STORE) : S with type t = M.t = struct
     | Some c -> Codecs.Chain.create repr c
     | None -> Ok Codecs.Chain.default)
     >>= fun codecs ->
-    let meta =
-      AM.create
-        ~sep
-        ~codecs
-        ~dimension_names
-        ~attributes
-        ~shape
-        kind
-        fill_value
-        chunks
-    in
+    AM.create
+      ~sep
+      ~codecs
+      ~dimension_names
+      ~attributes
+      ~shape
+      kind
+      fill_value
+      chunks
+    >>= fun meta ->
     set t (ArrayNode.to_metakey node) (AM.encode meta);
     Result.ok @@
     make_implicit_groups_explicit t @@

--- a/lib/storage/storage_intf.ml
+++ b/lib/storage/storage_intf.ml
@@ -66,7 +66,7 @@ module type S = sig
       'a ->
       ArrayNode.t ->
       t ->
-      (unit, [> Codecs.error]) result
+      (unit, [> error ]) result
   (** [create_array ~sep ~dimension_names ~attributes ~codecs ~shape ~chunks kind fill node t]
       creates an array node in store [t] where:
       - Separator [sep] is used in the array's chunk key encoding.

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -2,7 +2,10 @@ module ExtPoint = struct
   type 'a t =
     {name : string
     ;configuration : 'a}
-  [@@deriving yojson, eq]
+
+  let ( = ) cmp x y =
+    (x.name = y.name) &&
+    cmp x.configuration y.configuration
 end
 
 type ('a, 'b) array_repr =
@@ -101,3 +104,8 @@ let get_name j =
 
 let prod x =
   Array.fold_left Int.mul 1 x
+
+let max x =
+  Array.fold_left
+    (fun acc v ->
+      if v <= acc then acc else v) Int.min_int x

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -9,12 +9,7 @@ module ExtPoint : sig
   (** The type representing a JSON extension point metadata configuration. *)
 
   type 'a t = {name : string ; configuration : 'a}
-  val equal : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
-  val of_yojson
-    : (Yojson.Safe.t -> ('a, string) result) ->
-      Yojson.Safe.t ->
-      ('a t, string) result
-  val to_yojson : ('a -> Yojson.Safe.t) -> 'a t -> Yojson.Safe.t
+  val ( = ) : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 end
 
 module Arraytbl : sig include Hashtbl.S with type key = int array end
@@ -67,3 +62,6 @@ val get_name : Yojson.Safe.t -> string
 
 val prod : int array -> int
 (** [prod x] returns the product of the elements of [x]. *)
+
+val max : int array -> int
+(** [max x] returns the maximum element of an integer array [x]. *)


### PR DESCRIPTION
Implementing these functions manually allows us to have more flexibility regarding how much varification is done during parsing of the JSON metadata documents and very specific error reporting.