### PR TITLE
Enforce shard index codec chain invariant

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ let array_node =
   Result.get_ok @@ ArrayNode.(group_node / "name");;
 
 let codec_chain =
-  {a2a = [Transpose [|2; 0; 1|]]
-  ;a2b = Bytes Big
-  ;b2b = [Gzip L2]};;
+  {a2a = [`Transpose [|2; 0; 1|]]
+  ;a2b = `Bytes Big
+  ;b2b = [`Gzip L2]};;
 
 FilesystemStore.create_array
   ~codecs:codec_chain
@@ -81,16 +81,16 @@ R[73,1]    -INF    -INF     -INF     -INF    -INF     -INF *)
 let config =
   {chunk_shape = [|5; 3; 5|]
   ;codecs =
-    {a2a = [Transpose [|2; 0; 1|]]
-    ;a2b = Bytes Little
-    ;b2b = [Gzip L5]}
+    {a2a = [`Transpose [|2; 0; 1|]]
+    ;a2b = `Bytes Little
+    ;b2b = [`Gzip L5]}
   ;index_codecs =
     {a2a = []
-    ;a2b = Bytes Big
-    ;b2b = [Crc32c]}
+    ;a2b = `Bytes Big
+    ;b2b = [`Crc32c]}
   ;index_location = Start};;
 let codec_chain =
-  {a2a = []; a2b = ShardingIndexed config; b2b = []};;
+  {a2a = []; a2b = `ShardingIndexed config; b2b = []};;
 
 let shard_node = Result.get_ok @@ ArrayNode.(group_node / "another");;
 

--- a/dune-project
+++ b/dune-project
@@ -23,13 +23,13 @@
    dune
    (ocaml (>= 4.14.2))
    yojson
-   ppx_deriving
    ezgzip
    owl
    stdint
    checkseum
-   (ounit2 :with-test)
    (odoc :with-doc)
+   (ounit2 :with-test)
+   (ppx_deriving :with-test)
    (bisect_ppx
      (and :dev (>= 2.5.0) :with-test)))
  (tags

--- a/lib/codecs/array_to_array.ml
+++ b/lib/codecs/array_to_array.ml
@@ -1,10 +1,9 @@
 module Ndarray = Owl.Dense.Ndarray.Generic
 
-type dimension_order = int array [@@deriving show]
+type dimension_order = int array
 
 type array_to_array =
   | Transpose of dimension_order
-  [@@deriving show]
 
 type error =
   [ `Transpose_order of dimension_order * string ]

--- a/lib/codecs/array_to_array.mli
+++ b/lib/codecs/array_to_array.mli
@@ -8,9 +8,6 @@ type array_to_array =
 type error =
   [ `Transpose_order of dimension_order * string ]
 
-val pp_array_to_array : Format.formatter -> array_to_array -> unit
-val show_array_to_array : array_to_array -> string
-
 module ArrayToArray : sig 
   val parse
     : ('a, 'b) Util.array_repr ->

--- a/lib/codecs/array_to_bytes.ml
+++ b/lib/codecs/array_to_bytes.ml
@@ -7,17 +7,14 @@ module Ndarray = Owl.Dense.Ndarray.Generic
 type endianness =
   | Little
   | Big
-  [@@deriving show]
 
 type loc =
   | Start
   | End
-  [@@deriving show]
 
 type array_to_bytes =
   | Bytes of endianness
   | ShardingIndexed of shard_config
-  [@@deriving show]
 
 and shard_config =
   {chunk_shape : int array
@@ -29,7 +26,6 @@ and chain =
   {a2a: array_to_array list
   ;a2b: array_to_bytes
   ;b2b: bytes_to_bytes list}
-  [@@deriving show]
 
 type error =
   [ Extensions.error

--- a/lib/codecs/array_to_bytes.mli
+++ b/lib/codecs/array_to_bytes.mli
@@ -20,9 +20,6 @@ and chain = {
   b2b: Bytes_to_bytes.bytes_to_bytes list;
 }
 
-val pp_chain : Format.formatter -> chain -> unit
-val show_chain : chain -> string
-
 type error =
   [ Extensions.error
   | Array_to_array.error

--- a/lib/codecs/bytes_to_bytes.ml
+++ b/lib/codecs/bytes_to_bytes.ml
@@ -2,12 +2,10 @@ module Ndarray = Owl.Dense.Ndarray.Generic
 
 type compression_level =
   | L0 | L1 | L2 | L3 | L4 | L5 | L6 | L7 | L8 | L9
-  [@@deriving show]
 
 type bytes_to_bytes =
   | Crc32c
   | Gzip of compression_level
-  [@@deriving show]
 
 type error = 
   [ `Gzip of Ezgzip.error ]

--- a/lib/codecs/bytes_to_bytes.mli
+++ b/lib/codecs/bytes_to_bytes.mli
@@ -10,9 +10,6 @@ type bytes_to_bytes =
 type error = 
   [ `Gzip of Ezgzip.error ]
 
-val pp_bytes_to_bytes : Format.formatter -> bytes_to_bytes -> unit
-val show_bytes_to_bytes : bytes_to_bytes -> string
-
 module BytesToBytes : sig
   val compute_encoded_size : int -> bytes_to_bytes -> int
   val encode : bytes_to_bytes -> string -> (string, [> error]) result

--- a/lib/codecs/codecs.ml
+++ b/lib/codecs/codecs.ml
@@ -77,10 +77,6 @@ and variable_to_internal_b2b b2b =
 module Chain = struct
   type t = chain
 
-  let pp = pp_chain
-
-  let show = show_chain
-
   let create : 
     type a b. (a, b) Util.array_repr -> codec_chain -> (t, [> error ]) result
     = fun repr cc ->

--- a/lib/codecs/codecs.mli
+++ b/lib/codecs/codecs.mli
@@ -1,69 +1,112 @@
+(** An array has an associated list of codecs. Each codec specifies a
+    bidirectional transform (an encode transform and a decode transform).
+    This module contains building blocks for creating and working with
+    a chain of codecs. *)
+
 module Ndarray = Owl.Dense.Ndarray.Generic
 
+(** The type of [array -> array] codecs. *)
 type arraytoarray =
   [ `Transpose of int array ]
 
+(** A type representing valid Gzip codec compression levels. *)
 type compression_level =
   | L0 | L1 | L2 | L3 | L4 | L5 | L6 | L7 | L8 | L9
 
+(** A type representing [bytes -> bytes] codecs that produce
+    fixed sized encoded strings. *)
 type fixed_bytestobytes =
   [ `Crc32c ]
+
+(** A type representing [bytes -> bytes] codecs that produce
+    variable sized encoded strings. *)
 type variable_bytestobytes =
   [ `Gzip of compression_level ]
+
+(** The type of [bytes -> bytes] codecs. *)
 type bytestobytes =
   [ fixed_bytestobytes | variable_bytestobytes ]
 
+(** A type representing the configured endianness of an array. *)
 type endianness = Little | Big
 
+(** A type representing the location of a shard's index array in
+    an encoded byte string. *)
 type loc = Start | End
 
+(** The type of [array -> bytes] codecs. *)
 type arraytobytes =
   [ `Bytes of endianness
   | `ShardingIndexed of sharding_config ]
 
+(** A type representing the Sharding indexed codec's configuration parameters. *)
 and sharding_config =
   {chunk_shape : int array
   ;codecs : bytestobytes shard_chain
   ;index_codecs : fixed_bytestobytes shard_chain
   ;index_location : loc}
 
+(** A type representing the chain of codecs used to encode/decode
+    a shard's bytes and its index array. *)
 and 'a shard_chain = {
   a2a: arraytoarray list;
   a2b: arraytobytes;
   b2b: 'a list;
 }
 
+(** A type used to build a user-defined chain of codecs when creating a Zarr array. *)
 type codec_chain = {
   a2a: arraytoarray list;
   a2b: arraytobytes;
   b2b: bytestobytes list;
 }
 
+(** The type of errors returned upon failure when an calling a function
+  on a {!Chain} type. *)
 type error =
   [ `Extension of string 
   | `Gzip of Ezgzip.error
   | `Transpose_order of int array * string
   | `Sharding of int array * int array * string ]
 
+(** A module containing functions to encode/decode an array chunk using a
+    predefined set of codecs. *)
 module Chain : sig
+  (** A type representing a valid chain of codecs for
+      decoding/encoding a Zarr array chunk. *)
   type t
 
+  (** [create r c] returns a type representing a chain of codecs defined by
+      chain [c] and decoded array representation type [r]. *)
   val create :
     ('a, 'b) Util.array_repr -> codec_chain -> (t, [> error ]) result
 
+  (** [default] returns the default codec chain that contains only
+      the required codecs as defined in the Zarr Version 3 specification. *)
   val default : t
 
+  (** [compute_encoded_size init t] returns the size (in bytes) of the
+      encoded byte string given the size [init] of its decoded representation. *)
   val compute_encoded_size : int -> t -> int
 
+  (** [encode t x] computes the encoded byte string representation of
+      array chunk [x]. Returns an error upon failure. *)
   val encode :
     t -> ('a, 'b) Ndarray.t -> (string, [> error ]) result
 
+  (** [decode t repr x] decodes the byte string [x] using codec chain [t]
+      and decoded representation type [repr]. Returns an error upon failure.*)
   val decode :
     t -> ('a, 'b) Util.array_repr -> string -> (('a, 'b) Ndarray.t, [> error]) result
 
+  (** [x = y] returns true if chain [x] is equal to chain [y],
+      and false otherwise. *)
   val ( = ) : t -> t -> bool
 
+  (** [of_yojson x] returns a code chain of type {!t} from its json object
+      representation. *)
   val of_yojson : Yojson.Safe.t -> (t, string) result
 
+  (** [to_yojson x] returns a json object representation of codec chain [x]. *)
   val to_yojson : t -> Yojson.Safe.t
 end

--- a/lib/codecs/codecs.mli
+++ b/lib/codecs/codecs.mli
@@ -39,34 +39,31 @@ type codec_chain = {
   b2b: bytestobytes list;
 }
 
-type error = Array_to_bytes.error
+type error =
+  [ `Extension of string 
+  | `Gzip of Ezgzip.error
+  | `Transpose_order of int array * string
+  | `Sharding of int array * int array * string ]
 
 module Chain : sig
   type t
 
-  val create
-    : ('a, 'b) Util.array_repr -> codec_chain -> (t, [> error]) result
+  val create :
+    ('a, 'b) Util.array_repr -> codec_chain -> (t, [> error ]) result
 
   val default : t
 
   val compute_encoded_size : int -> t -> int
 
-  val encode
-    : t -> ('a, 'b) Ndarray.t -> (string, [> error]) result
+  val encode :
+    t -> ('a, 'b) Ndarray.t -> (string, [> error ]) result
 
-  val decode
-    : t ->
-      ('a, 'b) Util.array_repr ->
-      string ->
-      (('a, 'b) Ndarray.t, [> error]) result
+  val decode :
+    t -> ('a, 'b) Util.array_repr -> string -> (('a, 'b) Ndarray.t, [> error]) result
 
   val ( = ) : t -> t -> bool
 
   val of_yojson : Yojson.Safe.t -> (t, string) result
 
   val to_yojson : t -> Yojson.Safe.t
-
-  val pp : Format.formatter -> t -> unit
-
-  val show : t -> string
 end

--- a/lib/dune
+++ b/lib/dune
@@ -9,9 +9,6 @@
    checkseum)
  (ocamlopt_flags
    (:standard -O3))
- (preprocess
-   (pps
-     ppx_deriving.show))
  (instrumentation
    (backend bisect_ppx)))
 

--- a/lib/storage/storage_intf.ml
+++ b/lib/storage/storage_intf.ml
@@ -56,7 +56,7 @@ module type S = sig
     : ?sep:[< `Dot | `Slash > `Slash ] ->
       ?dimension_names:string option list ->
       ?attributes:Yojson.Safe.t ->
-      ?codecs:Codecs.chain ->
+      ?codecs:Codecs.codec_chain ->
       shape:int array ->
       chunks:int array ->
       ('a, 'b) Bigarray.kind ->

--- a/test/test_codecs.ml
+++ b/test/test_codecs.ml
@@ -114,8 +114,7 @@ let tests = [
 
   let str = Chain.to_yojson c |> Yojson.Safe.to_string in
   (match Chain.of_yojson @@ Yojson.Safe.from_string str with
-  | Ok v ->
-    assert_equal ~printer:Chain.show v c;
+  | Ok v -> assert_equal v c;
   | Error _ ->
     assert_failure
       "a serialized chain should successfully deserialize"))

--- a/test/test_codecs.ml
+++ b/test/test_codecs.ml
@@ -35,7 +35,7 @@ let bytes_encode_decode
         assert_equal
           ~printer:Owl_pretty.dsnda_to_string
           arr
-          (Result.get_ok decoded)) [Bytes Little; Bytes Big]
+          (Result.get_ok decoded)) [`Bytes Little; `Bytes Big]
 
 let tests = [
 "test codec chain" >:: (fun _ ->
@@ -48,20 +48,20 @@ let tests = [
   let shard_cfg =
     {chunk_shape = [|2; 5; 5|]
     ;index_location = End
-    ;index_codecs = {a2a = []; a2b = Bytes Little; b2b = [Crc32c]}
-    ;codecs = {a2a = [Transpose [|0; 1; 2|]]; a2b = Bytes Big; b2b = [Gzip L1]}}
+    ;index_codecs = {a2a = []; a2b = `Bytes Little; b2b = [`Crc32c]}
+    ;codecs = {a2a = [`Transpose [|0; 1; 2|]]; a2b = `Bytes Big; b2b = [`Gzip L1]}}
   in
   let chain =
-    {a2a = [Transpose [|2; 1; 0; 3|]]
-    ;a2b = ShardingIndexed shard_cfg
-    ;b2b = [Crc32c; Gzip L9]}
+    {a2a = [`Transpose [|2; 1; 0; 3|]]
+    ;a2b = `ShardingIndexed shard_cfg
+    ;b2b = [`Crc32c; `Gzip L9]}
   in
   assert_bool
     "" @@
     Result.is_error @@
     Chain.create decoded_repr chain; 
 
-  let chain = {chain with a2a = [Transpose [|2; 1; 0|]]} in
+  let chain = {chain with a2a = [`Transpose [|2; 1; 0|]]} in
   let c = Chain.create decoded_repr chain in
   assert_bool "" @@ Result.is_ok c;
   let c = Result.get_ok c in
@@ -72,7 +72,7 @@ let tests = [
 
   let c' =
     Result.get_ok @@
-    Chain.create decoded_repr {chain with b2b = [Crc32c]}
+    Chain.create decoded_repr {chain with b2b = [`Crc32c]}
   in
   let init_size = 
     (Array.fold_left Int.mul 1 decoded_repr.shape) *
@@ -197,7 +197,7 @@ let tests = [
     ;fill_value = Complex.zero}
   in
   let chain =
-    {a2a = [Transpose [||]]; a2b = Bytes Little; b2b = []}
+    {a2a = [`Transpose [||]]; a2b = `Bytes Little; b2b = []}
   in
   assert_bool
     "" @@ 
@@ -207,7 +207,7 @@ let tests = [
     "" @@ 
     Result.is_error @@
     Chain.create decoded_repr
-    {chain with a2a = [Transpose [|4; 0; 1|]]})
+    {chain with a2a = [`Transpose [|4; 0; 1|]]})
 ;
 
 "test sharding indexed codec" >:: (fun _ ->
@@ -324,11 +324,11 @@ let tests = [
   let cfg =
     {chunk_shape = [|3; 5; 5|]
     ;index_location = Start
-    ;index_codecs = {a2a = []; a2b = Bytes Little; b2b = []}
-    ;codecs = {a2a = []; a2b = Bytes Big; b2b = []}}
+    ;index_codecs = {a2a = []; a2b = `Bytes Little; b2b = []}
+    ;codecs = {a2a = []; a2b = `Bytes Big; b2b = []}}
   in
   let chain =
-    {a2a = []; a2b = ShardingIndexed cfg; b2b = []} in
+    {a2a = []; a2b = `ShardingIndexed cfg; b2b = []} in
   (*test failure for chunk shape not evenly dividing shard. *)
   assert_bool
     "chunk shape must always evenly divide a shard" @@
@@ -337,11 +337,11 @@ let tests = [
   assert_bool
     "chunk shape must have same size as shard dimensionality" @@
     Result.is_error @@ Chain.create decoded_repr @@ 
-    {a2a = []; a2b = ShardingIndexed {cfg with chunk_shape = [|5|]}; b2b = []};
+    {a2a = []; a2b = `ShardingIndexed {cfg with chunk_shape = [|5|]}; b2b = []};
 
   let chain =
     {a2a = []
-    ;a2b = ShardingIndexed {cfg with chunk_shape = [|5; 5; 5|]}
+    ;a2b = `ShardingIndexed {cfg with chunk_shape = [|5; 5; 5|]}
     ;b2b = []}
   in
   let c = Chain.create decoded_repr chain in
@@ -432,14 +432,14 @@ let tests = [
       decoded_repr.shape
       decoded_repr.fill_value
   in
-  let chain = {a2a = []; a2b = Bytes Little; b2b = []}
+  let chain = {a2a = []; a2b = `Bytes Little; b2b = []}
   in
   List.iter
     (fun level ->
       let c =
-        Chain.create decoded_repr {chain with b2b = [Gzip level]} in
+        Chain.create decoded_repr {chain with b2b = [`Gzip level]} in
       assert_bool
-        "Creating Gzip chain should not fail." @@
+        "Creating `Gzip chain should not fail." @@
         Result.is_ok c;
       let c = Result.get_ok c in
       let enc = Chain.encode c arr in

--- a/test/test_metadata.ml
+++ b/test/test_metadata.ml
@@ -80,7 +80,6 @@ let test_array_metadata
     ~printer:show_int_array shape @@ ArrayMetadata.shape meta;
 
   assert_equal
-    ~printer:Codecs.Chain.show
     Codecs.Chain.default @@
     ArrayMetadata.codecs meta;
 

--- a/test/test_storage.ml
+++ b/test/test_storage.ml
@@ -75,7 +75,7 @@ let test_store
   let r =
     M.create_array
       ~sep:`Dot
-      ~codecs:{a2a = []; a2b = Bytes Big; b2b = []}
+      ~codecs:{a2a = []; a2b = `Bytes Big; b2b = []}
       ~shape:[|100; 100; 50|]
       ~chunks:[|10; 15; 20|]
       Bigarray.Complex64

--- a/zarr.opam
+++ b/zarr.opam
@@ -13,13 +13,13 @@ depends: [
   "dune" {>= "3.15"}
   "ocaml" {>= "4.14.2"}
   "yojson"
-  "ppx_deriving"
   "ezgzip"
   "owl"
   "stdint"
   "checkseum"
-  "ounit2" {with-test}
   "odoc" {with-doc}
+  "ounit2" {with-test}
+  "ppx_deriving" {with-test}
   "bisect_ppx" {dev & >= "2.5.0" & with-test}
 ]
 build: [


### PR DESCRIPTION
closes #15 

The V3 spec insists that the codec chain for a shard index array
must not include compression codecs like Gzip since it would make
it impractical to calculate index bytes size. This commit
ensures this invariant is not violated by making a shard's index
codec chain correct by construction. That is, specifying a non-fixed
size bytes-to-bytes codec in the `index_codec` field is a compile time
error.