### PR TITLE
Ensure index_codec JSON field is parsed correctly.

### DIFF
--- a/lib/codecs/array_to_bytes.ml
+++ b/lib/codecs/array_to_bytes.ml
@@ -233,7 +233,9 @@ end = struct
       Result.error @@ `Sharding (t.chunk_shape, repr.shape, msg))
     >>= fun () ->
     parse_chain repr t.codecs >>= fun () ->
-    parse_chain repr t.index_codecs
+    (* must add one dimension to the representation of the index array. *)
+    parse_chain
+      {repr with shape = Array.append repr.shape [|2|]} t.index_codecs
 
   let compute_encoded_size input_size t =
     List.fold_left BytesToBytes.compute_encoded_size

--- a/lib/codecs/array_to_bytes.mli
+++ b/lib/codecs/array_to_bytes.mli
@@ -1,3 +1,6 @@
+open Array_to_array
+open Bytes_to_bytes
+
 module Ndarray = Owl.Dense.Ndarray.Generic
 
 type endianness = Little | Big
@@ -10,15 +13,14 @@ type array_to_bytes =
 
 and shard_config =
   {chunk_shape : int array
-  ;codecs : chain
-  ;index_codecs : chain
+  ;codecs : any_bytes_to_bytes sharding_chain
+  ;index_codecs : fixed bytes_to_bytes sharding_chain
   ;index_location : loc}
 
-and chain = {
-  a2a: Array_to_array.array_to_array list;
+and 'a sharding_chain = {
+  a2a: array_to_array list;
   a2b: array_to_bytes;
-  b2b: Bytes_to_bytes.bytes_to_bytes list;
-}
+  b2b: 'a list}
 
 type error =
   [ Extensions.error

--- a/lib/codecs/bytes_to_bytes.mli
+++ b/lib/codecs/bytes_to_bytes.mli
@@ -3,17 +3,23 @@ module Ndarray = Owl.Dense.Ndarray.Generic
 type compression_level =
   | L0 | L1 | L2 | L3 | L4 | L5 | L6 | L7 | L8 | L9
 
-type bytes_to_bytes =
-  | Crc32c
-  | Gzip of compression_level
+type fixed = F
+type variable = V
+
+type _ bytes_to_bytes =
+  | Crc32c : fixed bytes_to_bytes
+  | Gzip : compression_level -> variable bytes_to_bytes
+
+type any_bytes_to_bytes =
+  | Any : _ bytes_to_bytes -> any_bytes_to_bytes
 
 type error = 
   [ `Gzip of Ezgzip.error ]
 
 module BytesToBytes : sig
-  val compute_encoded_size : int -> bytes_to_bytes -> int
-  val encode : bytes_to_bytes -> string -> (string, [> error]) result
-  val decode : bytes_to_bytes -> string -> (string, [> error]) result
-  val of_yojson : Yojson.Safe.t -> (bytes_to_bytes, string) result
-  val to_yojson : bytes_to_bytes -> Yojson.Safe.t
+  val compute_encoded_size : int -> fixed bytes_to_bytes -> int
+  val encode : any_bytes_to_bytes -> string -> (string, [> error]) result
+  val decode : any_bytes_to_bytes -> string -> (string, [> error]) result
+  val of_yojson : Yojson.Safe.t -> (any_bytes_to_bytes, string) result
+  val to_yojson : any_bytes_to_bytes -> Yojson.Safe.t
 end

--- a/lib/codecs/codecs.ml
+++ b/lib/codecs/codecs.ml
@@ -19,9 +19,9 @@ type bytestobytes =
 
 type arraytobytes =
   [ `Bytes of endianness
-  | `ShardingIndexed of sharding_config ]
+  | `ShardingIndexed of shard_config ]
 
-and sharding_config =
+and shard_config =
   {chunk_shape : int array
   ;codecs : bytestobytes shard_chain
   ;index_codecs : fixed_bytestobytes shard_chain
@@ -94,19 +94,6 @@ module Chain = struct
 
   let default : t =
     {a2a = []; a2b = ArrayToBytes.default; b2b = []}
-
-  let compute_encoded_size : int -> t -> int = fun input_size t ->
-    List.fold_left BytesToBytes.compute_encoded_size
-      (ArrayToBytes.compute_encoded_size
-         (List.fold_left ArrayToArray.compute_encoded_size
-            input_size t.a2a) t.a2b)
-      (List.map
-        (function
-        | Any Crc32c -> Crc32c
-        | Any _ ->
-          let msg =
-            "Cannot compute encoded size for variable-size codecs."
-          in failwith msg) t.b2b)
 
   let encode :
     type a b. t -> (a, b) Ndarray.t -> (string, [> error ]) result

--- a/lib/codecs/codecs.mli
+++ b/lib/codecs/codecs.mli
@@ -37,10 +37,10 @@ type loc = Start | End
 (** The type of [array -> bytes] codecs. *)
 type arraytobytes =
   [ `Bytes of endianness
-  | `ShardingIndexed of sharding_config ]
+  | `ShardingIndexed of shard_config ]
 
 (** A type representing the Sharding indexed codec's configuration parameters. *)
-and sharding_config =
+and shard_config =
   {chunk_shape : int array
   ;codecs : bytestobytes shard_chain
   ;index_codecs : fixed_bytestobytes shard_chain
@@ -84,10 +84,6 @@ module Chain : sig
   (** [default] returns the default codec chain that contains only
       the required codecs as defined in the Zarr Version 3 specification. *)
   val default : t
-
-  (** [compute_encoded_size init t] returns the size (in bytes) of the
-      encoded byte string given the size [init] of its decoded representation. *)
-  val compute_encoded_size : int -> t -> int
 
   (** [encode t x] computes the encoded byte string representation of
       array chunk [x]. Returns an error upon failure. *)

--- a/test/test_codecs.ml
+++ b/test/test_codecs.ml
@@ -67,7 +67,7 @@ let tests = [
   let c = Result.get_ok c in
   assert_raises
     ~msg:"Encoded size cannot be computed for compression codecs."
-    (Failure "Cannot compute encoded size of Gzip codec.")
+    (Failure "Cannot compute encoded size for variable-size codecs.")
     (fun () -> Chain.compute_encoded_size 0 c);
 
   let c' =
@@ -310,6 +310,19 @@ let tests = [
           "index_codecs":
             [{"name": "bytes", "configuration": {"endian": "big"}},
              {"name": "UNKNOWN_BYTESTOBYTES_CODEC"}],
+          "codecs":
+            [{"name": "bytes", "configuration": {"endian": "big"}}]}}]|}
+    ~msg:"Must be exactly one array->bytes codec.";
+  (* test violation of index_codec invariant when it contains variable-sized codecs. *)
+  decode_chain
+    ~str:{|[
+      {"name": "sharding_indexed",
+       "configuration":
+         {"index_location": "start",
+          "chunk_shape": [5, 5, 5],
+          "index_codecs":
+            [{"name": "bytes", "configuration": {"endian": "big"}},
+             {"name": "gzip", "configuration": {"level": 1}}],
           "codecs":
             [{"name": "bytes", "configuration": {"endian": "big"}}]}}]|}
     ~msg:"Must be exactly one array->bytes codec.";


### PR DESCRIPTION
This ensures that parsing a JSON index_codecs field that contains
variable-size codecs fails.

This also splits bytes_to_bytes codecs into fixed and variable
using GADTs.