### PR TITLE
Use more familiar names for endianness variants.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ let array_node =
   Result.get_ok @@ ArrayNode.(group_node / "name");;
 
 FilesystemStore.create_array
-  ~codecs:[`Transpose [|2; 0; 1|]; `Bytes Big; `Gzip L2]
+  ~codecs:[`Transpose [|2; 0; 1|]; `Bytes BE; `Gzip L2]
   ~shape:[|100; 100; 50|]
   ~chunks:[|10; 15; 20|]
   Bigarray.Float32 
@@ -75,8 +75,8 @@ R[73,1]    -INF    -INF     -INF     -INF    -INF     -INF *)
 ```ocaml
 let config =
   {chunk_shape = [|5; 3; 5|]
-  ;codecs = [`Transpose [|2; 0; 1|]; `Bytes Little; `Gzip L5]
-  ;index_codecs = [`Bytes Big; `Crc32c]
+  ;codecs = [`Transpose [|2; 0; 1|]; `Bytes LE; `Gzip L5]
+  ;index_codecs = [`Bytes BE; `Crc32c]
   ;index_location = Start};;
 
 let shard_node = Result.get_ok @@ ArrayNode.(group_node / "another");;

--- a/lib/codecs/array_to_bytes.ml
+++ b/lib/codecs/array_to_bytes.ml
@@ -11,8 +11,8 @@ module BytesCodec = struct
   let compute_encoded_size (input_size : int) = input_size
 
   let endian_module = function
-    | Little -> (module Ebuffer.Little : Ebuffer.S)
-    | Big -> (module Ebuffer.Big : Ebuffer.S)
+    | LE -> (module Ebuffer.Little : Ebuffer.S)
+    | BE -> (module Ebuffer.Big : Ebuffer.S)
 
   let encode :
     type a b. (a, b) Ndarray.t -> endianness -> (string, [> error]) result
@@ -67,8 +67,8 @@ module BytesCodec = struct
   let to_yojson e =
     let endian =
       match e with
-      | Little -> "little"
-      | Big -> "big"
+      | LE -> "little"
+      | BE -> "big"
     in
     `Assoc
     [("name", `String "bytes")
@@ -78,8 +78,8 @@ module BytesCodec = struct
     match Yojson.Safe.Util.(member "configuration" x |> to_assoc) with
     | [("endian", `String e)] ->
       (match e with
-      | "little" -> Ok Little
-      | "big" -> Ok Big
+      | "little" -> Ok LE
+      | "big" -> Ok BE
       | s ->
         Result.error @@ "Unsupported bytes endianness: " ^ s)
     | _ -> Error "Invalid bytes codec configuration."
@@ -105,7 +105,7 @@ module rec ArrayToBytes : sig
   val to_yojson : array_tobytes -> Yojson.Safe.t
 end = struct
 
-  let default = `Bytes Little
+  let default = `Bytes LE
 
   let parse t decoded_repr =
     match t with

--- a/lib/codecs/codecs_intf.ml
+++ b/lib/codecs/codecs_intf.ml
@@ -13,7 +13,7 @@ type variable_bytestobytes =
 type bytestobytes =
   [ fixed_bytestobytes | variable_bytestobytes ]
 
-type endianness = Little | Big
+type endianness = LE | BE
 
 type loc = Start | End
 
@@ -65,7 +65,7 @@ module type Interface = sig
     [ fixed_bytestobytes | variable_bytestobytes ]
 
   (** A type representing the configured endianness of an array. *)
-  type endianness = Little | Big
+  type endianness = LE | BE
 
   (** A type representing the location of a shard's index array in
       an encoded byte string. *)

--- a/lib/storage/memory.ml
+++ b/lib/storage/memory.ml
@@ -1,4 +1,10 @@
-module StrMap = Util.StrMap
+module HashableString = struct
+  type t = string
+  let hash = Hashtbl.hash
+  let equal = String.equal
+end
+
+module StrMap = Hashtbl.Make (HashableString)
 
 let create () = StrMap.create 16
 

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -13,28 +13,14 @@ type ('a, 'b) array_repr =
   ;shape : int array
   ;fill_value : 'a}
 
-module HashableArray = struct  
-  type t = int array
-  let hash = Hashtbl.hash
-  let equal x y = Array.for_all2 Int.equal x y
-end
-
 module ComparableArray = struct
   type t = int array
   let compare = Stdlib.compare
 end
 
-module HashableString = struct
-  type t = string
-  let hash = Hashtbl.hash
-  let equal = String.equal
-end
-
 module ArraySet = Set.Make (ComparableArray)
 
-module Arraytbl = Hashtbl.Make (HashableArray)
-
-module StrMap = Hashtbl.Make (HashableString)
+module ArrayMap = Map.Make (ComparableArray)
 
 module Result_syntax = struct
   let ( >>= ) = Result.bind

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -12,11 +12,8 @@ module ExtPoint : sig
   val ( = ) : ('a -> 'a -> bool) -> 'a t -> 'a t -> bool
 end
 
-module StrMap : sig include Hashtbl.S with type key = string end
-(** A hashtable with string keys. *)
-
-module Arraytbl : sig include Hashtbl.S with type key = int array end
-(** A hashtable with integer array keys. *)
+module ArrayMap : sig include Map.S with type key = int array end
+(** A finite map over integer array keys. *)
 
 module ArraySet : sig include Set.S with type elt = int array end
 (** A hash set of integer array elements. *)

--- a/test/test_codecs.ml
+++ b/test/test_codecs.ml
@@ -35,7 +35,7 @@ let bytes_encode_decode
         assert_equal
           ~printer:Owl_pretty.dsnda_to_string
           arr
-          (Result.get_ok decoded)) [`Bytes Little; `Bytes Big]
+          (Result.get_ok decoded)) [`Bytes LE; `Bytes BE]
 
 let tests = [
 "test codec chain" >:: (fun _ ->
@@ -48,8 +48,8 @@ let tests = [
   let shard_cfg =
     {chunk_shape = [|2; 5; 5|]
     ;index_location = End
-    ;index_codecs = [`Bytes Little; `Crc32c]
-    ;codecs = [`Transpose [|0; 1; 2|]; `Bytes Big; `Gzip L1]}
+    ;index_codecs = [`Bytes LE; `Crc32c]
+    ;codecs = [`Transpose [|0; 1; 2|]; `Bytes BE; `Gzip L1]}
   in
   let chain  =
     [`Transpose [|2; 1; 0; 3|]; `ShardingIndexed shard_cfg; `Crc32c; `Gzip L9]
@@ -60,7 +60,7 @@ let tests = [
     Chain.create decoded_repr chain; 
 
   let chain  =
-    [`Transpose [|2; 1; 0|]; `ShardingIndexed shard_cfg; `Bytes Big]
+    [`Transpose [|2; 1; 0|]; `ShardingIndexed shard_cfg; `Bytes BE]
   in
   assert_bool
     "Chain with more than 1 array->bytes codec cannot be created" @@
@@ -185,7 +185,7 @@ let tests = [
     ;kind = Bigarray.Complex32
     ;fill_value = Complex.zero}
   in
-  let chain = [`Transpose [||]; `Bytes Little] in
+  let chain = [`Transpose [||]; `Bytes LE] in
   assert_bool
     "" @@ 
     Result.is_error @@
@@ -193,7 +193,7 @@ let tests = [
   assert_bool
     "Transpose codec with misisng dimensions should fail chain creation." @@ 
     Result.is_error @@
-    Chain.create decoded_repr [`Transpose [|4; 0; 1|]; `Bytes Little])
+    Chain.create decoded_repr [`Transpose [|4; 0; 1|]; `Bytes LE])
 ;
 
 "test sharding indexed codec" >:: (fun _ ->
@@ -323,8 +323,8 @@ let tests = [
   let cfg =
     {chunk_shape = [|3; 5; 5|]
     ;index_location = Start
-    ;index_codecs = [`Bytes Little; `Crc32c]
-    ;codecs = [`Bytes Big]}
+    ;index_codecs = [`Bytes LE; `Crc32c]
+    ;codecs = [`Bytes BE]}
   in
   let chain = [`ShardingIndexed cfg] in
   (*test failure for chunk shape not evenly dividing shard. *)
@@ -440,7 +440,7 @@ let tests = [
       decoded_repr.shape
       decoded_repr.fill_value
   in
-  let chain = [`Bytes Little] in
+  let chain = [`Bytes LE] in
   List.iter
     (fun level ->
       let c =

--- a/test/test_storage.ml
+++ b/test/test_storage.ml
@@ -62,13 +62,13 @@ let test_store
   `ShardingIndexed {
     chunk_shape = [|5; 1; 5|];
     index_location = Start;
-    index_codecs = [`Bytes Big];
-    codecs = [`Bytes Little; `Gzip L2]}
+    index_codecs = [`Bytes BE];
+    codecs = [`Bytes LE; `Gzip L2]}
   in
   let cfg =
     {chunk_shape = [|2; 5; 5|]
     ;index_location = End
-    ;index_codecs = [`Bytes Little; `Crc32c]
+    ;index_codecs = [`Bytes LE; `Crc32c]
     ;codecs = [`Transpose [|2; 0; 1|]; nested_sharding; `Gzip L1]} in
   let anode = ArrayNode.(gnode / "arrnode") |> Result.get_ok in
   let r =
@@ -99,7 +99,7 @@ let test_store
 
   let r =
     M.create_array
-      ~codecs:[`Bytes Big]
+      ~codecs:[`Bytes BE]
       ~shape:[|100; 100; 50|]
       ~chunks:[|10; 15; 20|]
       Bigarray.Complex64


### PR DESCRIPTION
Also:
- This makes reasoning about the flow of code easier since a finite
map can be built using a single fold over the keys and values.