### PR TITLE
Fix Char decoding when using Bytes codec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,30 +15,23 @@ open Zarr.Node
 open Zarr.Codecs
 open Zarr.Storage
 
-module Ndarray = Owl.Dense.Ndarray.Generic
-
-let store =
-  Result.get_ok @@
-  FilesystemStore.open_or_create ~file_perm:0o777 "testdata.zarr";;
+let store = Result.get_ok @@ FilesystemStore.open_or_create "testdata.zarr";;
 ```
 ### create group
 ```ocaml
-let group_node =
-  Result.get_ok @@ GroupNode.of_path "/some/group";;
-
+let group_node = Result.get_ok @@ GroupNode.of_path "/some/group";;
 FilesystemStore.create_group store group_node;;
 ```
 ### create an array
 ```ocaml
-let array_node =
-  Result.get_ok @@ ArrayNode.(group_node / "name");;
-
+let array_node = Result.get_ok @@ ArrayNode.(group_node / "name");;
+(* creates an array with char data type and fill value '?' *)
 FilesystemStore.create_array
   ~codecs:[`Transpose [|2; 0; 1|]; `Bytes BE; `Gzip L2]
   ~shape:[|100; 100; 50|]
   ~chunks:[|10; 15; 20|]
-  Bigarray.Float32 
-  Float.neg_infinity
+  Bigarray.Char 
+  '?'
   array_node
   store;;
 ```
@@ -47,29 +40,28 @@ FilesystemStore.create_array
 let slice = Owl_types.[|R [0; 20]; I 10; R []|];;
 let x =
   Result.get_ok @@
-  FilesystemStore.get_array store array_node slice Bigarray.Float32;;
+  FilesystemStore.get_array store array_node slice Bigarray.Char;;
 
 (* Do some computation on the array slice *)
-let x' = Ndarray.map (fun _ -> Owl_stats_dist.uniform_rvs 0. 10.) x;;
+let x' =
+  Owl.Dense.Ndarray.Generic.map
+    (fun _ -> Owl_stats_dist.uniform_int_rvs ~a:0 ~b:255 |> Char.chr) x;;
 FilesystemStore.set_array store array_node slice x';;
 
 FilesystemStore.get_array
-  store
-  array_node
-  Owl_types.[|R [0; 73]; L [10; 16]; R[0; 5]|]
-  Bigarray.Float32;;
-(*           C0      C1       C2       C3      C4       C5 
- R[0,0]   6.106 4.76659   2.6251  5.76799 3.95144  1.95656 
- R[0,1]    -INF    -INF     -INF     -INF    -INF     -INF 
- R[1,0] 7.31409 6.64764 0.980762 0.530332 4.17086  5.45735 
- R[1,1]    -INF    -INF     -INF     -INF    -INF     -INF 
- R[2,0] 3.52729 5.15036 0.488728  4.40894 7.62077 0.891417 
-            ...     ...      ...      ...     ...      ... 
-R[71,1]    -INF    -INF     -INF     -INF    -INF     -INF 
-R[72,0]    -INF    -INF     -INF     -INF    -INF     -INF 
-R[72,1]    -INF    -INF     -INF     -INF    -INF     -INF 
-R[73,0]    -INF    -INF     -INF     -INF    -INF     -INF 
-R[73,1]    -INF    -INF     -INF     -INF    -INF     -INF *)
+  store array_node Owl_types.[|R [0; 73]; I 10; R [0; 5]|] Bigarray.Char;;
+(*       C0  C1  C2  C3  C4  C5 
+ R[0,0]   =      Ð   �       
+ R[1,0]   d   ®   ê   ~   1    
+ R[2,0]      £      Q   Ò   ø 
+ R[3,0]   e   ^      Ò   Ê   B 
+ R[4,0]   ú   2   �   1   `   n 
+        ... ... ... ... ... ... 
+R[69,0]   ?   ?   ?   ?   ?   ? 
+R[70,0]   ?   ?   ?   ?   ?   ? 
+R[71,0]   ?   ?   ?   ?   ?   ? 
+R[72,0]   ?   ?   ?   ?   ?   ? 
+R[73,0]   ?   ?   ?   ?   ?   ?  *)
 ```
 ### create an array with sharding
 ```ocaml

--- a/lib/codecs/ebuffer.ml
+++ b/lib/codecs/ebuffer.ml
@@ -32,8 +32,8 @@ end
 module Little = struct
   let contents = Buffer.contents
   let add_int8 = Buffer.add_int8
-  let add_char buf v = Char.code v |> add_int8 buf
   let add_uint8 = Buffer.add_uint8
+  let add_char buf v = Char.code v |> add_uint8 buf
   let add_int16 = Buffer.add_int16_le
   let add_uint16 = Buffer.add_uint16_le
   let add_int32 = Buffer.add_int32_le
@@ -50,8 +50,8 @@ module Little = struct
     Int64.bits_of_float im |> add_int64 buf
 
   let get_int8 = String.get_int8
-  let get_char buf i = get_int8 buf i |> Char.chr
   let get_uint8 = String.get_uint8
+  let get_char buf i = get_uint8 buf i |> Char.chr
   let get_int16 = String.get_int16_le
   let get_uint16 = String.get_uint16_le
   let get_int32 = String.get_int32_le
@@ -71,8 +71,8 @@ end
 module Big = struct
   let contents = Buffer.contents
   let add_int8 = Buffer.add_int8
-  let add_char buf v = Char.code v |> add_int8 buf
   let add_uint8 = Buffer.add_uint8
+  let add_char buf v = Char.code v |> add_uint8 buf
   let add_int16 = Buffer.add_int16_be
   let add_uint16 = Buffer.add_uint16_be
   let add_int32 = Buffer.add_int32_be
@@ -89,8 +89,8 @@ module Big = struct
     Int64.bits_of_float im |> Buffer.add_int64_be buf
 
   let get_int8 = String.get_int8
-  let get_char buf i = get_int8 buf i |> Char.chr
   let get_uint8 = String.get_uint8
+  let get_char buf i = get_uint8 buf i |> Char.chr
   let get_int16 = String.get_int16_be
   let get_uint16 = String.get_uint16_be
   let get_int32 = String.get_int32_be


### PR DESCRIPTION
This uses uint8 to read the data instead of signed int8 before
converting the integer into a character. Previously, this incorrectly
used signed int8 which has range [-128,127] instead of the expected [0,
255].