### PR TITLE
Replace metadata optional argument with attrs.

### DIFF
--- a/lib/codecs/array_to_array.ml
+++ b/lib/codecs/array_to_array.ml
@@ -8,8 +8,8 @@ module TransposeCodec = struct
   let compute_encoded_representation
     : type a b.
       int array ->
-      (a, b) Util.array_repr ->
-      ((a, b) Util.array_repr, [> error]) result
+      (a, b) array_repr ->
+      ((a, b) array_repr, [> error]) result
     = fun t decoded ->
       try
         let shape = Array.map (fun x -> decoded.shape.(x)) t in
@@ -45,7 +45,7 @@ module TransposeCodec = struct
 
   let parse
     : type a b.
-      (a, b) Util.array_repr ->
+      (a, b) array_repr ->
       int array ->
       (unit, [> error]) result
     = fun repr o ->
@@ -124,8 +124,8 @@ module ArrayToArray = struct
 
   let compute_encoded_representation :
     arraytoarray ->
-    ('a, 'b) Util.array_repr ->
-    (('a, 'b) Util.array_repr, [> error]) result
+    ('a, 'b) array_repr ->
+    (('a, 'b) array_repr, [> error]) result
     = fun t repr ->
     match t with
     | `Transpose o ->

--- a/lib/codecs/array_to_array.mli
+++ b/lib/codecs/array_to_array.mli
@@ -3,13 +3,13 @@ open Codecs_intf
 module ArrayToArray : sig 
   val parse :
     arraytoarray ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     (unit, [> error]) result
   val compute_encoded_size : int -> arraytoarray -> int
   val compute_encoded_representation :
     arraytoarray ->
-    ('a, 'b) Util.array_repr ->
-    (('a, 'b) Util.array_repr, [> error]) result
+    ('a, 'b) array_repr ->
+    (('a, 'b) array_repr, [> error]) result
   val encode :
     arraytoarray ->
     ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t ->

--- a/lib/codecs/array_to_bytes.ml
+++ b/lib/codecs/array_to_bytes.ml
@@ -42,7 +42,7 @@ module BytesCodec = struct
   let decode :
     type a b.
     string ->
-    (a, b) Util.array_repr ->
+    (a, b) array_repr ->
     endianness ->
     ((a, b) Ndarray.t, [> `Store_read of string | error]) result
     = fun buf decoded t ->
@@ -88,7 +88,7 @@ end
 module rec ArrayToBytes : sig
   val parse :
     array_tobytes ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     (unit, [> error]) result
   val compute_encoded_size : int -> array_tobytes -> int
   val default : array_tobytes
@@ -98,7 +98,7 @@ module rec ArrayToBytes : sig
     (string, [> error]) result
   val decode :
     array_tobytes ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     string ->
     (('a, 'b) Ndarray.t, [> `Store_read of string | error]) result
   val of_yojson : Yojson.Safe.t -> (array_tobytes, string) result
@@ -128,7 +128,7 @@ end = struct
 
   let decode :
     array_tobytes ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     string ->
     (('a, 'b) Ndarray.t, [> error]) result
     = fun t repr b ->
@@ -150,7 +150,7 @@ end
 
 and ShardingIndexedCodec : sig
   type t = internal_shard_config
-  val parse : t -> ('a, 'b) Util.array_repr -> (unit, [> error]) result
+  val parse : t -> ('a, 'b) array_repr -> (unit, [> error]) result
   val compute_encoded_size : int -> t -> int
   val encode : t -> ('a, 'b) Ndarray.t -> (string, [> error]) result
   val partial_encode :
@@ -159,7 +159,7 @@ and ShardingIndexedCodec : sig
       (string list, [> `Store_read of string | error ] as 'c) result) ->
     partial_setter ->
     int ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     (int array * 'a) list ->
     (unit, 'c) result
   val partial_decode :
@@ -167,12 +167,12 @@ and ShardingIndexedCodec : sig
     ((int * int option) list ->
       (string list, [> `Store_read of string | error ] as 'c) result) ->
     int ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     (int * int array) list ->
     ((int * 'a) list, 'c) result
   val decode :
     t ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     string ->
     (('a, 'b) Ndarray.t, [> `Store_read of string | error]) result
   val of_yojson : Yojson.Safe.t -> (t, string) result
@@ -191,7 +191,7 @@ end = struct
 
   let parse :
     internal_shard_config ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     (unit, [> error]) result
     = fun t r ->
     (match Array.(length r.shape = length t.chunk_shape) with
@@ -282,7 +282,7 @@ end = struct
   let rec decode_chain :
     type a b.
     bytestobytes internal_chain ->
-    (a, b) Util.array_repr ->
+    (a, b) array_repr ->
     string ->
     ((a, b) Ndarray.t, [> error]) result
     = fun t repr x ->
@@ -328,7 +328,7 @@ end = struct
       (string list, [> `Store_read of string | error ]) result) ->
     partial_setter ->
     int ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     (int array * 'a) list ->
     (unit, [> `Store_read of string | error ]) result
     = fun t get_partial set_partial bytesize repr pairs ->
@@ -386,7 +386,7 @@ end = struct
 
   and decode :
     t ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     string ->
     (('a, 'b) Ndarray.t, [> `Store_read of string | error]) result
     = fun t repr b ->
@@ -427,7 +427,7 @@ end = struct
     ((int * int option) list ->
       (string list, [> `Store_read of string | error ]) result) ->
     int ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     (int * int array) list ->
     ((int * 'a) list, [> `Store_read of string | error ]) result
     = fun t get_partial bsize repr pairs ->

--- a/lib/codecs/array_to_bytes.mli
+++ b/lib/codecs/array_to_bytes.mli
@@ -3,7 +3,7 @@ open Codecs_intf
 module ArrayToBytes : sig
   val parse :
     array_tobytes ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     (unit, [> error]) result
   val compute_encoded_size : int -> array_tobytes -> int
   val default : array_tobytes
@@ -13,7 +13,7 @@ module ArrayToBytes : sig
     (string, [> error]) result
   val decode :
     array_tobytes ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     string ->
     (('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
     ,[> `Store_read of string | error]) result
@@ -29,7 +29,7 @@ module ShardingIndexedCodec : sig
       (string list, [> `Store_read of string | error ] as 'c) result) ->
     partial_setter ->
     int ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     (int array * 'a) list ->
     (unit, 'c) result
   val partial_decode :
@@ -37,7 +37,7 @@ module ShardingIndexedCodec : sig
     ((int * int option) list ->
       (string list, [> `Store_read of string | error ] as 'c) result) ->
     int ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     (int * int array) list ->
     ((int * 'a) list, 'c) result
 end

--- a/lib/codecs/codecs.ml
+++ b/lib/codecs/codecs.ml
@@ -78,9 +78,6 @@ module Chain = struct
     >>= ArrayToBytes.parse a2b >>| fun () ->
     {a2a; a2b; b2b}
 
-  let default : t =
-    {a2a = []; a2b = ArrayToBytes.default; b2b = []}
-
   let encode :
     t ->
     ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t ->

--- a/lib/codecs/codecs.ml
+++ b/lib/codecs/codecs.ml
@@ -30,7 +30,7 @@ module Chain = struct
   type t = bytestobytes internal_chain
 
   let rec create : 
-    type a b. (a, b) Util.array_repr -> codec_chain -> (t, [> error ]) result
+    type a b. (a, b) array_repr -> codec_chain -> (t, [> error ]) result
     = fun repr cc ->
     let a2a, rest =
       List.partition_map
@@ -100,7 +100,7 @@ module Chain = struct
       (string list, [> `Store_read of string | error] as 'c) result) ->
     partial_setter ->
     int ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     (int array * 'a) list ->
     (unit, 'c) result
     = fun t f g bsize repr pairs ->
@@ -114,7 +114,7 @@ module Chain = struct
     ((int * int option) list ->
       (string list, [> `Store_read of string | error ] as 'c) result) ->
     int ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     (int * int array) list ->
     ((int * 'a) list, 'c) result
     = fun t f s repr pairs ->
@@ -125,7 +125,7 @@ module Chain = struct
 
   let decode :
     t ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     string ->
     (('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
     ,[> `Store_read of string | error]) result

--- a/lib/codecs/codecs.mli
+++ b/lib/codecs/codecs.mli
@@ -17,10 +17,6 @@ module Chain : sig
   val create :
     ('a, 'b) Util.array_repr -> codec_chain -> (t, [> error ]) result
 
-  (** [default] returns the default codec chain that contains only
-      the required codecs as defined in the Zarr Version 3 specification. *)
-  val default : t
-
   (** [is_just_sharding t] is [true] if the codec chain [t] contains only
       the [sharding_indexed] codec. *)
   val is_just_sharding : t -> bool

--- a/lib/codecs/codecs.mli
+++ b/lib/codecs/codecs.mli
@@ -15,7 +15,7 @@ module Chain : sig
   (** [create r c] returns a type representing a chain of codecs defined by
       chain [c] and decoded array representation type [r]. *)
   val create :
-    ('a, 'b) Util.array_repr -> codec_chain -> (t, [> error ]) result
+    ('a, 'b) array_repr -> codec_chain -> (t, [> error ]) result
 
   (** [is_just_sharding t] is [true] if the codec chain [t] contains only
       the [sharding_indexed] codec. *)
@@ -32,7 +32,7 @@ module Chain : sig
       and decoded representation type [repr]. Returns an error upon failure.*)
   val decode :
     t ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     string ->
     (('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
     ,[> `Store_read of string | error ]) result
@@ -43,7 +43,7 @@ module Chain : sig
       (string list, [> `Store_read of string | error ] as 'c) result) ->
     partial_setter ->
     int ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     (int array * 'a) list ->
     (unit, 'c) result
 
@@ -52,7 +52,7 @@ module Chain : sig
     ((int * int option) list ->
       (string list, [> `Store_read of string | error ] as 'c) result) ->
     int ->
-    ('a, 'b) Util.array_repr ->
+    ('a, 'b) array_repr ->
     (int * int array) list ->
     ((int * 'a) list, 'c) result
 

--- a/lib/codecs/codecs_intf.ml
+++ b/lib/codecs/codecs_intf.ml
@@ -41,6 +41,11 @@ type error =
 
 type partial_setter = ?append:bool -> (int * string) list -> unit
 
+type ('a, 'b) array_repr =
+  {kind : ('a, 'b) Bigarray.kind
+  ;shape : int array
+  ;fill_value : 'a}
+
 module type Interface = sig
   (** The type of [array -> array] codecs. *)
   type arraytoarray =
@@ -105,4 +110,11 @@ module type Interface = sig
     | `Sharding of int array * int array * string ]
 
   type partial_setter = ?append:bool -> (int * string) list -> unit
+
+  (** The type summarizing the decoded/encoded representation of a Zarr array
+      or chunk. *)
+  type ('a, 'b) array_repr =
+    {kind : ('a, 'b) Bigarray.kind
+    ;shape : int array
+    ;fill_value : 'a}
 end

--- a/lib/metadata.ml
+++ b/lib/metadata.ml
@@ -300,7 +300,7 @@ module ArrayMetadata = struct
     Yojson.Safe.to_string @@ to_yojson t
 
   let decode b = 
-    of_yojson @@ Yojson.Safe.from_string b
+    of_yojson @@ Yojson.Safe.from_string b >>? fun msg -> `Store_read msg
 
   let update_attributes t attrs =
     {t with attributes = attrs}
@@ -398,7 +398,7 @@ module GroupMetadata = struct
     Ok {zarr_format; node_type; attributes}
 
   let decode s = 
-    of_yojson @@ Yojson.Safe.from_string s
+    of_yojson @@ Yojson.Safe.from_string s >>? fun msg -> `Store_read msg
 
   let encode t =
     Yojson.Safe.to_string @@ to_yojson t

--- a/lib/metadata.ml
+++ b/lib/metadata.ml
@@ -116,9 +116,9 @@ module ArrayMetadata = struct
 
   let create
     ?(sep=`Slash)
-    ?(codecs=Codecs.Chain.default)
     ?(dimension_names=[])
     ?(attributes=`Null)
+    ~codecs
     ~shape
     kind
     fv

--- a/lib/metadata.mli
+++ b/lib/metadata.mli
@@ -35,17 +35,18 @@ module ArrayMetadata : sig
 
   val create :
     ?sep:[< `Dot | `Slash > `Slash ] ->
-    ?codecs:Codecs.Chain.t ->
     ?dimension_names:string option list ->
     ?attributes:Yojson.Safe.t ->
+    codecs:Codecs.Chain.t ->
     shape:int array ->
     ('a, 'b) Bigarray.kind ->
     'a ->
     int array ->
     (t, [> error ]) result
-  (** [create ~shape kind fv cshp] Creates a new array metadata document
-      with shape [shape], fill value [fv], data type [kind] and chunk shape
-      [cshp]. This operation returns an error if chunk shape is invalid. *)
+  (** [create ~codecs ~shape kind fv cshp] Creates a new array metadata
+      document with codec chain [codecs], shape [shape], fill value [fv],
+      data type [kind] and chunk shape [cshp]. This operation returns an
+      error if chunk shape is invalid. *)
 
   val encode : t -> string
   (** [encode t] returns a byte string representing a JSON Zarr array metadata. *)

--- a/lib/metadata.mli
+++ b/lib/metadata.mli
@@ -51,7 +51,7 @@ module ArrayMetadata : sig
   val encode : t -> string
   (** [encode t] returns a byte string representing a JSON Zarr array metadata. *)
 
-  val decode : string -> (t, string) result
+  val decode : string -> (t, [> `Store_read of string ]) result
   (** [decode s] decodes a bytes string [s] into a {!ArrayMetadata.t}
       type, and returns an error if the decoding process fails. *)
 
@@ -120,7 +120,7 @@ module GroupMetadata : sig
   val encode : t -> string
   (** [encode t] returns a byte string representing a JSON Zarr group metadata. *)
 
-  val decode : string -> (t, string) result
+  val decode : string -> (t, [> `Store_read of string ]) result
   (** [decode s] decodes a bytes string [s] into a {!t} type, and returns
       an error if the decoding process fails. *)
 

--- a/lib/storage/storage.ml
+++ b/lib/storage/storage.ml
@@ -20,12 +20,11 @@ module Make (M : STORE) : S with type t = M.t = struct
   let array_exists t node =
     M.is_member t @@ ArrayNode.to_metakey node
 
-  let rec create_group ?metadata t node =
+  let rec create_group ?(attrs=`Null) t node =
     if group_exists t node then ()
     else
-      (match metadata, GroupNode.to_metakey node with
-      | Some m, k -> set t k @@ GM.encode m;
-      | None, k -> set t k @@ GM.(default |> encode));
+      let k = GroupNode.to_metakey node in
+      set t k GM.(update_attributes default attrs |> encode);
       make_implicit_groups_explicit t @@ GroupNode.parent node
 
   and make_implicit_groups_explicit t = function

--- a/lib/storage/storage.ml
+++ b/lib/storage/storage.ml
@@ -43,7 +43,7 @@ module Make (M : STORE) : S with type t = M.t = struct
     node
     t
     =
-    let repr = {kind; fill_value; shape = chunks} in
+    let repr = Codecs.{kind; fill_value; shape = chunks} in
     Codecs.Chain.create repr codecs >>= fun chain ->
     AM.create
       ~sep ~codecs:chain ~dimension_names ~attributes ~shape
@@ -132,7 +132,7 @@ module Make (M : STORE) : S with type t = M.t = struct
           (Indexing.coords_of_slice slice arr_shape) (Ndarray.to_array x)
     in
     let fill_value = AM.fillvalue_of_kind meta kind in
-    let repr = {kind; fill_value; shape = AM.chunk_shape meta} in
+    let repr = Codecs.{kind; fill_value; shape = AM.chunk_shape meta} in
     let prefix = ArrayNode.to_key node ^ "/" in
     let chain = AM.codecs meta in
     ArraySet.fold
@@ -192,7 +192,7 @@ module Make (M : STORE) : S with type t = M.t = struct
     let chain = AM.codecs meta in
     let prefix = ArrayNode.to_key node ^ "/" in
     let fill_value = AM.fillvalue_of_kind meta kind in
-    let repr = {kind; fill_value; shape = AM.chunk_shape meta} in
+    let repr = Codecs.{kind; fill_value; shape = AM.chunk_shape meta} in
     ArraySet.fold
       (fun idx acc ->
         acc >>= fun xs ->

--- a/lib/storage/storage_intf.ml
+++ b/lib/storage/storage_intf.ml
@@ -54,7 +54,7 @@ module type S = sig
     : ?sep:[< `Dot | `Slash > `Slash ] ->
       ?dimension_names:string option list ->
       ?attributes:Yojson.Safe.t ->
-      ?codecs:Codecs.codec_chain ->
+      codecs:Codecs.codec_chain ->
       shape:int array ->
       chunks:int array ->
       ('a, 'b) Bigarray.kind ->

--- a/lib/storage/storage_intf.ml
+++ b/lib/storage/storage_intf.ml
@@ -45,10 +45,9 @@ module type S = sig
   type t
   (** The storage type. *)
 
-  val create_group
-    : ?metadata:GroupMetadata.t -> t -> GroupNode.t -> unit
-  (** [create_group ~meta t node] creates a group node in store [t]
-      containing metadata [meta]. This is a no-op if [node]
+  val create_group : ?attrs:Yojson.Safe.t -> t -> GroupNode.t -> unit
+  (** [create_group ?attrs t node] creates a group node in store [t]
+      containing attributes [attrs]. This is a no-op if [node]
       is already a member of this store. *)
 
   val create_array

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -8,14 +8,10 @@ module ExtPoint = struct
     cmp x.configuration y.configuration
 end
 
-module ComparableArray = struct
+module ArrayMap = Map.Make (struct
   type t = int array
   let compare = Stdlib.compare
-end
-
-module ArraySet = Set.Make (ComparableArray)
-
-module ArrayMap = Map.Make (ComparableArray)
+end)
 
 module Result_syntax = struct
   let ( >>= ) = Result.bind

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -8,11 +8,6 @@ module ExtPoint = struct
     cmp x.configuration y.configuration
 end
 
-type ('a, 'b) array_repr =
-  {kind : ('a, 'b) Bigarray.kind
-  ;shape : int array
-  ;fill_value : 'a}
-
 module ComparableArray = struct
   type t = int array
   let compare = Stdlib.compare

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -8,9 +8,6 @@ end
 module ArrayMap : sig include Map.S with type key = int array end
 (** A finite map over integer array keys. *)
 
-module ArraySet : sig include Set.S with type elt = int array end
-(** A hash set of integer array elements. *)
-
 module Result_syntax : sig
   (** Result monad operator syntax. *)
 

--- a/lib/util.mli
+++ b/lib/util.mli
@@ -1,10 +1,3 @@
-type ('a, 'b) array_repr =
-  {kind : ('a, 'b) Bigarray.kind
-  ;shape : int array
-  ;fill_value : 'a}
-(** The type summarizing the decoded/encoded representation of a Zarr array
-    or chunk. *)
-
 module ExtPoint : sig
   (** The type representing a JSON extension point metadata configuration. *)
 

--- a/lib/zarr.ml
+++ b/lib/zarr.ml
@@ -1,4 +1,3 @@
-type ('a, 'b) array_repr = ('a, 'b) Util.array_repr
 module Node = Node
 module Indexing = Util.Indexing
 module ArrayMetadata = Metadata.ArrayMetadata

--- a/lib/zarr.mli
+++ b/lib/zarr.mli
@@ -1,4 +1,3 @@
-type ('a, 'b) array_repr = ('a, 'b) Util.array_repr
 module Node = Node
 module Indexing = Util.Indexing
 module ArrayMetadata = Metadata.ArrayMetadata

--- a/test/test_codecs.ml
+++ b/test/test_codecs.ml
@@ -1,5 +1,4 @@
 open OUnit2
-open Zarr
 open Zarr.Codecs
 
 module Ndarray = Owl.Dense.Ndarray.Generic

--- a/test/test_metadata.ml
+++ b/test/test_metadata.ml
@@ -9,7 +9,7 @@ let decode_bad_group_metadata ~str ~msg =
   | Ok _ ->
     assert_failure
       "Impossible to decode an ill-formed JSON group metadata document.";
-  | Error s ->
+  | Error (`Store_read s) ->
     assert_equal ~printer:Fun.id msg s
 
 let group = [
@@ -159,7 +159,7 @@ let decode_bad_array_metadata ~str ~msg =
   | Ok _ ->
     assert_failure
       "Impossible to decode an ill-formed JSON array metadata document.";
-  | Error s ->
+  | Error (`Store_read s) ->
     assert_equal ~printer:Fun.id msg s
 
 let test_encode_decode_fill_value fv =

--- a/test/test_metadata.ml
+++ b/test/test_metadata.ml
@@ -59,14 +59,16 @@ let test_array_metadata
     a ->
     unit
   = fun ?dimension_names ~shape ~chunks kind bad_kind fv ->
+  let repr : (a, b) array_repr = {kind; fill_value = fv; shape = chunks} in
+  let codecs = Result.get_ok @@ Codecs.Chain.create repr [`Bytes LE] in
   let meta =
     match dimension_names with
     | Some d ->
       Result.get_ok @@
-      ArrayMetadata.create ~shape ~dimension_names:d kind fv chunks
+      ArrayMetadata.create ~codecs ~shape ~dimension_names:d kind fv chunks
     | None ->
       Result.get_ok @@
-      ArrayMetadata.create ~shape kind fv chunks
+      ArrayMetadata.create ~codecs ~shape kind fv chunks
   in
   (match ArrayMetadata.encode meta |> ArrayMetadata.decode with
   | Ok v ->
@@ -81,9 +83,6 @@ let test_array_metadata
   assert_equal
     ~printer:show_int_array shape @@ ArrayMetadata.shape meta;
 
-  assert_equal
-    Codecs.Chain.default @@
-    ArrayMetadata.codecs meta;
 
   assert_equal
     ~printer:show_int_array

--- a/test/test_metadata.ml
+++ b/test/test_metadata.ml
@@ -59,7 +59,7 @@ let test_array_metadata
     a ->
     unit
   = fun ?dimension_names ~shape ~chunks kind bad_kind fv ->
-  let repr : (a, b) array_repr = {kind; fill_value = fv; shape = chunks} in
+  let repr = Codecs.{kind; fill_value = fv; shape = chunks} in
   let codecs = Result.get_ok @@ Codecs.Chain.create repr [`Bytes LE] in
   let meta =
     match dimension_names with

--- a/test/test_storage.ml
+++ b/test/test_storage.ml
@@ -40,20 +40,15 @@ let test_store
     M.find_all_nodes store;
 
   let attrs = `Assoc [("questions", `String "answer")] in
-  M.create_group 
-    ~metadata:GroupMetadata.(update_attributes default attrs)
-    store
-    gnode;
+  M.create_group ~attrs store gnode;
   (match M.group_metadata store gnode with
   | Ok meta ->
     assert_equal
-      ~printer:Yojson.Safe.show
-      attrs @@
-      GroupMetadata.attributes meta
+      ~printer:Yojson.Safe.show attrs @@ GroupMetadata.attributes meta
   | Error _ ->
     assert_failure
-      "group node created with specified values should
-      have metadata with said values.");
+      "group node created with specified attributes should
+      have metadata with said attributes.");
 
   let fake = ArrayNode.(gnode / "non-member") |> Result.get_ok in
   assert_equal ~printer:string_of_bool false @@ M.array_exists store fake;


### PR DESCRIPTION
- This replaces metadata with attrs in the create_group function. This
simplifies the function and removes unnecessary pattern matching on the
optional input value.

Also :
- This removes the use of a default codec chain since having a default
chain is subjective and forces the caller to specify a codec chain
to use everytime an array is created.
- Move array_repr to the codecs module where it is mainly used.
- Since we read the metadata from the store, it makes sense to use
`Store_read as the error return type when decoding.