### PR TITLE
Make sharded arrays written by other implementations readable.

### DIFF
--- a/lib/codecs/array_to_bytes.ml
+++ b/lib/codecs/array_to_bytes.ml
@@ -35,10 +35,6 @@ module BytesCodec = struct
     | Int -> Ndarray.iter (add_int buf) x; Ok (contents buf)
     | Nativeint -> Ndarray.iter (add_nativeint buf) x; Ok (contents buf)
 
-  let mk_array kind shape init_fn =
-    let x = Array.init (Util.prod shape) init_fn in
-    Ok (Ndarray.of_array kind x shape)
-
   let decode :
     type a b.
     string ->
@@ -50,19 +46,19 @@ module BytesCodec = struct
     let open (val endian_module t) in
     let k, shp = decoded.kind, decoded.shape in
     match k, kind_size_in_bytes k with
-    | Char, _ -> mk_array k shp @@ get_char buf
-    | Int8_signed, _ -> mk_array k shp @@ get_int8 buf
-    | Int8_unsigned, _ -> mk_array k shp @@ get_int8 buf
-    | Int16_signed, s -> mk_array k shp @@ fun i -> get_int16 buf (i*s)
-    | Int16_unsigned, s -> mk_array k shp @@ fun i -> get_uint16 buf (i*s)
-    | Int32, s -> mk_array k shp @@ fun i -> get_int32 buf (i*s)
-    | Int64, s -> mk_array k shp @@ fun i -> get_int64 buf (i*s)
-    | Float32, s -> mk_array k shp @@ fun i -> get_float32 buf (i*s)
-    | Float64, s -> mk_array k shp @@ fun i -> get_float64 buf (i*s)
-    | Complex32, s -> mk_array k shp @@ fun i -> get_complex32 buf (i*s)
-    | Complex64, s -> mk_array k shp @@ fun i -> get_complex64 buf (i*s)
-    | Int, s -> mk_array k shp @@ fun i -> get_int buf (i*s)
-    | Nativeint, s -> mk_array k shp @@ fun i -> get_nativeint buf (i*s)
+    | Char, _ -> Ok (Ndarray.init k shp @@ get_char buf)
+    | Int8_signed, _ -> Ok (Ndarray.init k shp @@ get_int8 buf)
+    | Int8_unsigned, _ -> Ok (Ndarray.init k shp @@ get_uint8 buf)
+    | Int16_signed, s -> Ok (Ndarray.init k shp @@ fun i -> get_int16 buf (i*s))
+    | Int16_unsigned, s -> Ok (Ndarray.init k shp @@ fun i -> get_uint16 buf (i*s))
+    | Int32, s -> Ok (Ndarray.init k shp @@ fun i -> get_int32 buf (i*s))
+    | Int64, s -> Ok (Ndarray.init k shp @@ fun i -> get_int64 buf (i*s))
+    | Float32, s -> Ok (Ndarray.init k shp @@ fun i -> get_float32 buf (i*s))
+    | Float64, s -> Ok (Ndarray.init k shp @@ fun i -> get_float64 buf (i*s))
+    | Complex32, s -> Ok (Ndarray.init k shp @@ fun i -> get_complex32 buf (i*s))
+    | Complex64, s -> Ok (Ndarray.init k shp @@ fun i -> get_complex64 buf (i*s))
+    | Int, s -> Ok (Ndarray.init k shp @@ fun i -> get_int buf (i*s))
+    | Nativeint, s -> Ok (Ndarray.init k shp @@ fun i -> get_nativeint buf (i*s))
 
   let to_yojson e =
     let endian =
@@ -80,8 +76,7 @@ module BytesCodec = struct
       (match e with
       | "little" -> Ok LE
       | "big" -> Ok BE
-      | s ->
-        Result.error @@ "Unsupported bytes endianness: " ^ s)
+      | s -> Error ("Unsupported bytes endianness: " ^ s))
     | _ -> Error "Invalid bytes codec configuration."
 end
 

--- a/lib/codecs/array_to_bytes.mli
+++ b/lib/codecs/array_to_bytes.mli
@@ -2,23 +2,22 @@ open Codecs_intf
 
 module ArrayToBytes : sig
   val parse :
-    array_tobytes ->
+    arraytobytes ->
     ('a, 'b) array_repr ->
     (unit, [> error]) result
-  val compute_encoded_size : int -> array_tobytes -> int
-  val default : array_tobytes
+  val compute_encoded_size : int -> fixed_arraytobytes -> int
   val encode :
-    array_tobytes ->
+    arraytobytes ->
     ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t ->
     (string, [> error]) result
   val decode :
-    array_tobytes ->
+    arraytobytes ->
     ('a, 'b) array_repr ->
     string ->
     (('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t
     ,[> `Store_read of string | error]) result
-  val of_yojson : Yojson.Safe.t -> (array_tobytes, string) result
-  val to_yojson : array_tobytes -> Yojson.Safe.t
+  val of_yojson : Yojson.Safe.t -> (arraytobytes, string) result
+  val to_yojson : arraytobytes -> Yojson.Safe.t
 end
 
 module ShardingIndexedCodec : sig

--- a/test/test_codecs.ml
+++ b/test/test_codecs.ml
@@ -382,8 +382,30 @@ let tests = [
     in
     let r = Chain.of_yojson @@ Yojson.Safe.from_string str in
     assert_bool
-      "Encoding this nested sharding chain should not fail" @@
-      Result.is_ok r)
+      "Encoding this nested sharding chain should not fail" @@ Result.is_ok r;
+  (* test if decoding of indexed_codec with sharding for array->bytes fails.*)
+  let str =
+    {|[
+      {"name": "sharding_indexed",
+       "configuration":
+         {"index_location": "start",
+          "chunk_shape": [5, 5, 5],
+          "codecs":
+            [{"name": "bytes", "configuration": {"endian": "big"}}],
+          "index_codecs":
+            [{"name": "sharding_indexed",
+               "configuration":
+                 {"index_location": "end",
+                  "chunk_shape": [5, 5, 5, 1],
+                  "index_codecs":
+                    [{"name": "bytes", "configuration": {"endian": "big"}}],
+                  "codecs":
+                    [{"name": "bytes", "configuration": {"endian": "big"}}]}}]}}]|}
+    in
+    let r = Chain.of_yojson @@ Yojson.Safe.from_string str in
+    assert_bool
+      "Decoding of index_codec chain with sharding should fail" @@
+      Result.is_error r)
 ;
 
 


### PR DESCRIPTION
closes #45 

Since bigarrays are limited to signed 64bit, sharding indexed could not correctly read arrays using $2^{64} -1$ index values to represent empty inner chunks. this commit fixes that issue.