### PR TITLE
Minimize `get_partial` and `set_partial` calls.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 2
 
       - name: setup-ocaml
-        uses: ocaml/setup-ocaml@master
+        uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
 


### PR DESCRIPTION
calling these for every requested inner chunk of a shard is expensive can can lead to a `Unix.EMFILE` error. This commit attempts to minimize the number of calls by making sure these are called once on all requested inner chunks of a shard. This should lead to a significant decrease in the number of open files open for read/write at the same time when using a Zarr_lwt `FilesystemStore`.