### PR TITLE
Use _s instead _p family of functions for Lwt_list.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ test: build
 
 .PHONY: test-cov
 test-cov: build
-	dune runtest --instrument-with bisect_ppx --force
+	OUNIT_CI=true dune runtest --instrument-with bisect_ppx --force
 	bisect-ppx-report summary --per-file
 
 .PHONY: show-cov

--- a/zarr-eio/src/deferred.ml
+++ b/zarr-eio/src/deferred.ml
@@ -2,7 +2,6 @@ type 'a t = 'a
 let return = Fun.id
 let return_unit = ()
 let iter = List.iter
-let iter_s = iter
 let fold_left = List.fold_left
 let map = List.map
 let concat_map = List.concat_map

--- a/zarr-eio/src/deferred.ml
+++ b/zarr-eio/src/deferred.ml
@@ -1,10 +1,9 @@
 type 'a t = 'a
 let return = Fun.id
 let return_unit = ()
-let iter = List.iter
+let iter f xs = Eio.Fiber.List.iter f xs
 let fold_left = List.fold_left
-let map = List.map
-let concat_map = List.concat_map
+let concat_map f xs = List.concat @@ Eio.Fiber.List.map f xs
 
 module Infix = struct
   let (>>=) x f = f x

--- a/zarr-eio/src/storage.ml
+++ b/zarr-eio/src/storage.ml
@@ -1,3 +1,8 @@
+module MemoryStore = struct
+  include Zarr.Storage.Make(Zarr.Memory.Make(Deferred))
+  let create = Zarr.Memory.create
+end
+
 module FilesystemStore = struct
   module FS = struct
     module Deferred = Deferred

--- a/zarr-eio/src/storage.mli
+++ b/zarr-eio/src/storage.mli
@@ -1,3 +1,12 @@
+module MemoryStore : sig
+  (** An in-memory storage backend for Zarr V3 hierarchy. *)
+
+  include Zarr.Storage.STORE with type 'a Deferred.t = 'a
+
+  val create : unit -> t
+  (** [create ()] returns a new In-memory Zarr store type. *)
+end
+
 module FilesystemStore : sig
   (** A local filesystem storage backend for a Zarr V3 hierarchy. *)
 

--- a/zarr-eio/test/test_eio.ml
+++ b/zarr-eio/test/test_eio.ml
@@ -167,5 +167,6 @@ let _ =
         (Zarr.Storage.Not_a_filesystem_store fn)
         (fun () -> FilesystemStore.open_store ~env fn);
 
+      test_storage (module MemoryStore) @@ MemoryStore.create ();
       test_storage (module FilesystemStore) s)
   ])

--- a/zarr-eio/test/test_eio.ml
+++ b/zarr-eio/test/test_eio.ml
@@ -147,14 +147,15 @@ let _ =
     (fun _ ->
       Eio_main.run @@ fun env ->
       let rand_num = string_of_int @@ Random.int 1_000_000 in
-      let tmp_dir = Filename.(concat (get_temp_dir_name ()) (rand_num ^ ".zarr/")) in
+      let tmp_dir = Filename.(concat (get_temp_dir_name ()) (rand_num ^ ".zarr")) in
       let s = FilesystemStore.create ~env tmp_dir in
 
       assert_raises
         (Sys_error (Format.sprintf "%s: File exists" tmp_dir))
         (fun () -> FilesystemStore.create ~env tmp_dir);
 
-      ignore @@ FilesystemStore.open_store ~env tmp_dir;
+      (* ensure it works with an extra "/" appended to directory name. *)
+      ignore @@ FilesystemStore.open_store ~env (tmp_dir ^ "/");
 
       let fakedir = "non-existant-zarr-store112345.zarr" in
       assert_raises

--- a/zarr-lwt/src/deferred.ml
+++ b/zarr-lwt/src/deferred.ml
@@ -3,7 +3,6 @@ let return = Lwt.return
 let return_unit = Lwt.return_unit
 let iter = Lwt_list.iter_s
 let fold_left = Lwt_list.fold_left_s
-let map = Lwt_list.map_s
 let concat_map f l = Lwt.map List.concat (Lwt_list.map_p f l)
 
 module Infix = struct

--- a/zarr-lwt/src/deferred.ml
+++ b/zarr-lwt/src/deferred.ml
@@ -1,10 +1,9 @@
 type 'a t = 'a Lwt.t
 let return = Lwt.return
 let return_unit = Lwt.return_unit
-let iter = Lwt_list.iter_p
-let iter_s = Lwt_list.iter_s
+let iter = Lwt_list.iter_s
 let fold_left = Lwt_list.fold_left_s
-let map = Lwt_list.map_p
+let map = Lwt_list.map_s
 let concat_map f l = Lwt.map List.concat (Lwt_list.map_p f l)
 
 module Infix = struct

--- a/zarr-lwt/test/test_lwt.ml
+++ b/zarr-lwt/test/test_lwt.ml
@@ -111,7 +111,8 @@ let _ =
         (Sys_error (Format.sprintf "%s: File exists" tmp_dir))
         (fun () -> FilesystemStore.create tmp_dir);
 
-      ignore @@ FilesystemStore.open_store tmp_dir;
+      (* ensure it works with an extra "/" appended to directory name. *)
+      ignore @@ FilesystemStore.open_store (tmp_dir ^ "/");
 
       let fakedir = "non-existant-zarr-store112345.zarr" in
       assert_raises

--- a/zarr-sync/src/deferred.ml
+++ b/zarr-sync/src/deferred.ml
@@ -3,7 +3,6 @@ let return x = x
 let return_unit = ()
 let iter = List.iter
 let fold_left = List.fold_left
-let map = List.map
 let concat_map = List.concat_map
 
 module Infix = struct

--- a/zarr-sync/src/deferred.ml
+++ b/zarr-sync/src/deferred.ml
@@ -2,7 +2,6 @@ type 'a t = 'a
 let return x = x
 let return_unit = ()
 let iter = List.iter
-let iter_s = iter
 let fold_left = List.fold_left
 let map = List.map
 let concat_map = List.concat_map

--- a/zarr-sync/test/test_sync.ml
+++ b/zarr-sync/test/test_sync.ml
@@ -158,7 +158,8 @@ let _ =
         (Sys_error (Format.sprintf "%s: File exists" tmp_dir))
         (fun () -> FilesystemStore.create tmp_dir);
 
-      ignore @@ FilesystemStore.open_store tmp_dir;
+      (* ensure it works with an extra "/" appended to directory name. *)
+      ignore @@ FilesystemStore.open_store (tmp_dir ^ "/");
 
       let fakedir = "non-existant-zarr-store112345.zarr" in
       assert_raises

--- a/zarr/src/storage/storage.ml
+++ b/zarr/src/storage/storage.ml
@@ -87,8 +87,7 @@ module Make (Io : Types.IO) = struct
   let erase_array_node t node =
     erase_prefix t @@ ArrayNode.to_key node ^ "/"
 
-  let erase_all_nodes t =
-    list t >>= Deferred.iter (erase t)
+  let erase_all_nodes t = erase_prefix t ""
 
   let write_array t node slice x =
     get t @@ ArrayNode.to_metakey node >>= fun b -> 

--- a/zarr/src/types.ml
+++ b/zarr/src/types.ml
@@ -4,7 +4,6 @@ module type Deferred = sig
   val return_unit : unit t
   val iter : ('a -> unit t) -> 'a list -> unit t
   val fold_left : ('acc -> 'a -> 'acc t) -> 'acc -> 'a list -> 'acc t
-  val map : ('a -> 'b t) -> 'a list -> 'b list t
   val concat_map : ('a -> 'b list t) -> 'a list -> 'b list t
   module Infix : sig
     val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
@@ -47,7 +46,6 @@ module type IO = sig
   val erase : t -> key -> unit Deferred.t
   val erase_prefix : t -> key -> unit Deferred.t
   val list : t -> key list Deferred.t
-  val list_prefix : t -> key -> key list Deferred.t
   val list_dir : t -> key -> (key list * prefix list) Deferred.t
   val is_member : t -> key -> bool Deferred.t
 end

--- a/zarr/src/types.ml
+++ b/zarr/src/types.ml
@@ -3,7 +3,6 @@ module type Deferred = sig
   val return : 'a -> 'a t
   val return_unit : unit t
   val iter : ('a -> unit t) -> 'a list -> unit t
-  val iter_s : ('a -> unit t) -> 'a list -> unit t
   val fold_left : ('acc -> 'a -> 'acc t) -> 'acc -> 'a list -> 'acc t
   val map : ('a -> 'b t) -> 'a list -> 'b list t
   val concat_map : ('a -> 'b list t) -> 'a list -> 'b list t

--- a/zarr/src/util.ml
+++ b/zarr/src/util.ml
@@ -104,3 +104,8 @@ let rec create_parent_dir fn perm =
     create_parent_dir parent_dir perm;
     Sys.mkdir parent_dir perm
   end
+
+let sanitize_dir dir =
+  match Filename.chop_suffix_opt ~suffix:"/" dir with
+  | None -> dir
+  | Some d -> d

--- a/zarr/src/util.mli
+++ b/zarr/src/util.mli
@@ -63,3 +63,6 @@ val max : int array -> int
 val create_parent_dir : string -> Unix.file_perm -> unit
 (** [create_parent_dir f p] creates all the parent directories of file name
     [f] if they don't exist given file permissions [p]. *)
+
+val sanitize_dir : string -> string
+(** [sanitize_dir d] Chops off any trailing '/' in directory path [d]. *)


### PR DESCRIPTION
This also add other minor optimizations like:
- optimizing the runtime of `list_prefix` and `list_dir` functions.
- remove `list_prefix` as a requirement for the `Zarr.Types.IO` signature.
- optimize `get_partial_values` and `set_partial_values` for MemoryStore.
- Add MemoryStore module for `Zarr-eio`.