### PR TITLE
Enforce correct sequencing of codecs in codec chain.

### DIFF
--- a/zarr/src/codecs/array_to_bytes.ml
+++ b/zarr/src/codecs/array_to_bytes.ml
@@ -333,10 +333,8 @@ end = struct
     let open Util.Result_syntax in
     let filter_partition f encoded =
       List.fold_right (fun c (l, r) ->
-        match f c with
-        | Ok v -> v :: l, r
-        | Error _ -> l, c :: r) encoded ([], [])
-    in
+        Result.fold ~ok:(fun v -> v :: l, r) ~error:(fun _ -> l, c :: r) @@ f c)
+        encoded ([], []) in
     let* codecs = match codecs with
       | [] -> Error "No codec chain specified for sharding_indexed."
       | y -> Ok y

--- a/zarr/src/codecs/codecs.ml
+++ b/zarr/src/codecs/codecs.ml
@@ -104,10 +104,8 @@ module Chain = struct
     let open Util.Result_syntax in
     let filter_partition f encoded =
       List.fold_right (fun c (l, r) ->
-        match f c with
-        | Ok v -> v :: l, r
-        | Error _ -> l, c :: r) encoded ([], [])
-    in
+        Result.fold ~ok:(fun v -> v :: l, r) ~error:(fun _ -> l, c :: r) @@ f c)
+        encoded ([], []) in
     let* codecs = match Yojson.Safe.Util.to_list x with
       | [] -> Error "No codec specified."
       | y -> Ok y

--- a/zarr/src/codecs/codecs_intf.ml
+++ b/zarr/src/codecs/codecs_intf.ml
@@ -1,6 +1,7 @@
-exception Bytes_to_bytes_invariant
+exception Array_to_bytes_invariant
 exception Invalid_transpose_order
 exception Invalid_sharding_chunk_shape
+exception Invalid_codec_ordering
 
 type arraytoarray =
   [ `Transpose of int array ]
@@ -48,14 +49,18 @@ type ('a, 'b) array_repr =
   ;shape : int array}
 
 module type Interface = sig
-  exception Bytes_to_bytes_invariant
-  (** raised when a codec chain contains more than 1 bytes->bytes codec. *)
+  exception Array_to_bytes_invariant
+  (** raised when a codec chain contains more than 1 array->bytes codec. *)
 
   exception Invalid_transpose_order
   (** raised when a codec chain contains a Transpose codec with an incorrect order. *)
 
   exception Invalid_sharding_chunk_shape
   (** raise when a codec chain contains a shardingindexed codec with an incorrect inner chunk shape. *)
+
+  exception Invalid_codec_ordering
+  (** raised when a codec chain has incorrect ordering of codecs. i.e if the
+      ordering is not [arraytoarray list -> 1 arraytobytes -> bytestobytes list]. *)
 
   (** The type of [array -> array] codecs. *)
   type arraytoarray =

--- a/zarr/test/test_codecs.ml
+++ b/zarr/test/test_codecs.ml
@@ -38,9 +38,14 @@ let tests = [
     (Zarr.Codecs.Invalid_transpose_order)
     (fun () -> Chain.create shape chain); 
 
-  let chain = [`Transpose [|2; 1; 0|]; `ShardingIndexed shard_cfg; `Bytes BE] in
+  let chain = [`ShardingIndexed shard_cfg; `Transpose [|2; 1; 0|]; `Gzip L0] in
   assert_raises
-    (Zarr.Codecs.Bytes_to_bytes_invariant)
+    (Zarr.Codecs.Invalid_codec_ordering)
+    (fun () -> Chain.create shape chain); 
+
+  let chain = [`Transpose [|2; 1; 0|]; `Crc32c] in
+  assert_raises
+    (Zarr.Codecs.Array_to_bytes_invariant)
     (fun () -> Chain.create shape chain); 
 
   let chain =


### PR DESCRIPTION
This ensures that creation of a codec chain fails if the sequencing of codecs in the list is not correct. That is if the sequencing is not exactly: arraytoarray list -> 1 array-to-bytes -> bytestobytes list. That is one must supply the codecs in the order in which they intend to apply the encode/decode sequence.