### PR TITLE
Add `rename` functionality for stores.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ List.map GroupNode.to_path g;;
 
 FilesystemStore.erase_group_node store group_node;;
 FilesystemStore.erase_all_nodes store;; (* clears the store *)
+FilesystemStore.rename_group store group_node;;
+FilesystemStore.rename_array store anode;;
 ```
 
 [1]: https://codecov.io/gh/zoj613/zarr-ml/graph/badge.svg?token=KOOG2Y1SH5

--- a/examples/readonly_zipstore.ml
+++ b/examples/readonly_zipstore.ml
@@ -83,6 +83,8 @@ end = struct
     let erase _ = raise Not_implemented
 
     let erase_prefix _ = raise Not_implemented
+
+    let rename _ = raise Not_implemented
   end
 
   (* this functor generates the public signature of our Zip file store. *)

--- a/zarr-eio/src/storage.ml
+++ b/zarr-eio/src/storage.ml
@@ -89,6 +89,9 @@ module FilesystemStore = struct
           | p when Eio.Path.is_directory p -> 
             Either.right @@ (fspath_to_key t p) ^ "/"
           | p -> Either.left @@ fspath_to_key t p) (Eio.Path.read_dir dir) 
+
+    let rename t k k' =
+      Eio.Path.rename (key_to_fspath t k) (key_to_fspath t k')
   end
 
   module U = Zarr.Util

--- a/zarr-eio/test/test_eio.ml
+++ b/zarr-eio/test/test_eio.ml
@@ -70,7 +70,7 @@ let test_storage
       assert_equal exp got)
     [[`ShardingIndexed cfg]; [`Bytes BE]];
 
-  let child = GroupNode.of_path "/some/child" in
+  let child = GroupNode.of_path "/some/child/group" in
   create_group store child;
   let arrays, groups = find_child_nodes store gnode in
   assert_equal
@@ -86,7 +86,22 @@ let test_storage
     List.fast_sort String.compare @@
     List.map ArrayNode.show ac @ List.map GroupNode.show gc in
   assert_equal
-    ~printer:string_of_list ["/"; "/arrnode"; "/some"; "/some/child"] got;
+    ~printer:string_of_list
+    ["/"; "/arrnode"; "/some"; "/some/child"; "/some/child/group"] got;
+
+  (* tests for renaming nodes *)
+  let some = GroupNode.of_path "/some/child" in
+  rename_array store anode "ARRAYNODE";
+  rename_group store some "CHILD";
+  let ac, gc = find_all_nodes store in
+  let got =
+    List.fast_sort String.compare @@
+    List.map ArrayNode.show ac @ List.map GroupNode.show gc in
+  assert_equal
+    ~printer:string_of_list
+    ["/"; "/ARRAYNODE"; "/some"; "/some/CHILD"; "/some/CHILD/group"] got;
+  (* restore old array node name. *)
+  rename_array store (ArrayNode.of_path "/ARRAYNODE") "arrnode";
 
   let nshape = [|25; 32; 10|] in
   reshape store anode nshape;

--- a/zarr-lwt/src/storage.ml
+++ b/zarr-lwt/src/storage.ml
@@ -124,6 +124,9 @@ module FilesystemStore = struct
           | p when Sys.is_directory p ->
             Either.right @@ (fspath_to_key t p) ^ "/"
           | p -> Either.left @@ fspath_to_key t p) files
+
+    let rename t k k' =
+      Lwt_unix.rename (key_to_fspath t k) (key_to_fspath t k')
   end
 
   module U = Zarr.Util

--- a/zarr-lwt/test/test_lwt.ml
+++ b/zarr-lwt/test/test_lwt.ml
@@ -71,7 +71,7 @@ let test_storage
       assert_equal exp got)
     [[`ShardingIndexed cfg]; [`Bytes BE]] >>= fun () ->
 
-  let child = GroupNode.of_path "/some/child" in
+  let child = GroupNode.of_path "/some/child/group" in
   create_group store child >>= fun () ->
   find_child_nodes store gnode >>= fun (arrays, groups) ->
   assert_equal
@@ -87,7 +87,22 @@ let test_storage
     List.fast_sort String.compare @@
     List.map ArrayNode.show ac @ List.map GroupNode.show gc in
   assert_equal
-    ~printer:string_of_list ["/"; "/arrnode"; "/some"; "/some/child"] got;
+    ~printer:string_of_list
+    ["/"; "/arrnode"; "/some"; "/some/child"; "/some/child/group"] got;
+
+  (* tests for renaming nodes *)
+  let some = GroupNode.of_path "/some/child" in
+  rename_array store anode "ARRAYNODE" >>= fun () ->
+  rename_group store some "CHILD" >>= fun () ->
+  find_all_nodes store >>= fun (ac, gc) ->
+  let got =
+    List.fast_sort String.compare @@
+    List.map ArrayNode.show ac @ List.map GroupNode.show gc in
+  assert_equal
+    ~printer:string_of_list
+    ["/"; "/ARRAYNODE"; "/some"; "/some/CHILD"; "/some/CHILD/group"] got;
+  (* restore old array node name. *)
+  rename_array store (ArrayNode.of_path "/ARRAYNODE") "arrnode" >>= fun () ->
 
   let nshape = [|25; 32; 10|] in
   reshape store anode nshape >>= fun () ->

--- a/zarr-sync/src/storage.ml
+++ b/zarr-sync/src/storage.ml
@@ -93,6 +93,9 @@ module FilesystemStore = struct
           | p when Sys.is_directory p ->
             Either.right @@ (fspath_to_key t p) ^ "/"
           | p -> Either.left @@ fspath_to_key t p) (Array.to_list @@ Sys.readdir dir)
+
+    let rename t k k' =
+      Sys.rename (key_to_fspath t k) (key_to_fspath t k')
   end
 
   module U = Zarr.Util

--- a/zarr-sync/src/storage.ml
+++ b/zarr-sync/src/storage.ml
@@ -4,7 +4,7 @@ module MemoryStore = struct
 end
 
 module FilesystemStore = struct
-  module FS = struct
+  module F = struct
     module Deferred = Deferred
 
     type t = {dirname : string; perm : Unix.file_perm}
@@ -16,59 +16,41 @@ module FilesystemStore = struct
     let key_to_fspath t key = Filename.concat t.dirname key
 
     let get t key =
-      try
-        In_channel.with_open_gen
-          In_channel.[Open_rdonly; Open_nonblock]
-          t.perm
-          (key_to_fspath t key)
-          In_channel.input_all
-      with
-      | Sys_error _ -> raise @@ Zarr.Storage.Key_not_found key
+      let p = key_to_fspath t key in
+      try In_channel.(with_open_gen [Open_rdonly; Open_nonblock] t.perm p input_all)
+      with Sys_error _ -> raise @@ Zarr.Storage.Key_not_found key
 
     let get_partial_values t key ranges =
-      In_channel.with_open_gen
-        In_channel.[Open_rdonly; Open_nonblock]
-        t.perm
-        (key_to_fspath t key)
-        (fun ic ->
-          let size = In_channel.length ic |> Int64.to_int in
-          List.map
-            (fun (ofs, len) ->
-              In_channel.seek ic @@ Int64.of_int ofs;
-              let l = Option.fold ~none:(size - ofs) ~some:Fun.id len in 
-              Option.get @@ In_channel.really_input_string ic l) ranges)
+      let f = [Open_rdonly; Open_nonblock] in
+      In_channel.with_open_gen f t.perm (key_to_fspath t key) @@ fun ic ->
+      let s = In_channel.length ic |> Int64.to_int in
+      ranges |> List.map @@ fun (ofs, len) ->
+      In_channel.seek ic @@ Int64.of_int ofs;
+      let l = Option.fold ~none:(s - ofs) ~some:Fun.id len in 
+      Option.get @@ In_channel.really_input_string ic l
 
-    let set t key value =
-      let filename = key_to_fspath t key in
-      Zarr.Util.create_parent_dir filename t.perm;
-      Out_channel.with_open_gen
-        Out_channel.[Open_wronly; Open_trunc; Open_creat; Open_nonblock]
-        t.perm
-        filename
-        (fun oc -> Out_channel.output_string oc value; Out_channel.flush oc)
+    let set t key v =
+      let p = key_to_fspath t key in
+      Zarr.Util.create_parent_dir p t.perm;
+      let f = [Open_wronly; Open_trunc; Open_creat; Open_nonblock] in
+      Out_channel.(with_open_gen f t.perm p @@ fun oc -> output_string oc v; flush oc)
 
     let set_partial_values t key ?(append=false) rvs =
-      let open Out_channel in
-      Out_channel.with_open_gen
-        [Open_nonblock; if append then Open_append else Open_wronly]
-        t.perm
-        (key_to_fspath t key)
-        (fun oc ->
-          List.iter
-            (fun (rs, value) ->
-              Out_channel.seek oc @@ Int64.of_int rs;
-              Out_channel.output_string oc value) rvs; Out_channel.flush oc)
+      let f = [Open_nonblock; if append then Open_append else Open_wronly] in
+      let p = key_to_fspath t key in
+      Out_channel.with_open_gen f t.perm p @@ fun oc ->
+      rvs |> List.iter (fun (rs, value) ->
+      Out_channel.seek oc @@ Int64.of_int rs;
+      Out_channel.output_string oc value);
+      Out_channel.flush oc
 
     let is_member t key = Sys.file_exists @@ key_to_fspath t key
 
     let erase t key = Sys.remove @@ key_to_fspath t key
 
     let size t key =
-      In_channel.with_open_gen
-        In_channel.[Open_rdonly; Open_nonblock]
-        t.perm
-        (key_to_fspath t key)
-        (fun ic -> In_channel.length ic |> Int64.to_int)
+      let f = [Open_rdonly; Open_nonblock] in
+      In_channel.(with_open_gen f t.perm (key_to_fspath t key) length) |> Int64.to_int
 
     let rec walk t acc dir =
       List.fold_left
@@ -87,15 +69,12 @@ module FilesystemStore = struct
 
     let list_dir t prefix =
       let dir = key_to_fspath t prefix in
-      List.partition_map 
-        (fun x ->
-          match Filename.concat dir x with
-          | p when Sys.is_directory p ->
-            Either.right @@ (fspath_to_key t p) ^ "/"
-          | p -> Either.left @@ fspath_to_key t p) (Array.to_list @@ Sys.readdir dir)
+      (Array.to_list @@ Sys.readdir dir) |> List.partition_map @@ fun x ->
+      match Filename.concat dir x with
+      | p when Sys.is_directory p -> Either.right @@ (fspath_to_key t p) ^ "/"
+      | p -> Either.left @@ fspath_to_key t p 
 
-    let rename t k k' =
-      Sys.rename (key_to_fspath t k) (key_to_fspath t k')
+    let rename t k k' = Sys.rename (key_to_fspath t k) (key_to_fspath t k')
   end
 
   module U = Zarr.Util
@@ -103,12 +82,12 @@ module FilesystemStore = struct
   let create ?(perm=0o700) dirname =
     U.create_parent_dir dirname perm;
     Sys.mkdir dirname perm;
-    FS.{dirname = U.sanitize_dir dirname; perm}
+    F.{dirname = U.sanitize_dir dirname; perm}
 
   let open_store ?(perm=0o700) dirname =
     if Sys.is_directory dirname
-    then FS.{dirname = U.sanitize_dir dirname; perm}
+    then F.{dirname = U.sanitize_dir dirname; perm}
     else raise @@ Zarr.Storage.Not_a_filesystem_store dirname
 
-  include Zarr.Storage.Make(FS)
+  include Zarr.Storage.Make(F)
 end

--- a/zarr/src/node.ml
+++ b/zarr/src/node.ml
@@ -1,4 +1,5 @@
 exception Node_invariant
+exception Cannot_rename_root
 
 (* Check if the path's name satisfies path invariants *)
 let rep_ok name =
@@ -78,6 +79,12 @@ module GroupNode = struct
 
   let pp fmt t =
     Format.fprintf fmt "%s" @@ show t
+
+  let rename t str =
+    match t with
+    | Cons (parent, _) when rep_ok str -> Cons (parent, str)
+    | Cons _ -> raise Node_invariant
+    | Root -> raise Cannot_rename_root
 end
 
 module ArrayNode = struct
@@ -129,4 +136,10 @@ module ArrayNode = struct
   let show = to_path
 
   let pp fmt t = Format.fprintf fmt "%s" @@ show t
+
+  let rename t name =
+    match t.parent with
+    | Some _ when rep_ok name -> {t with name}
+    | Some _ -> raise Node_invariant
+    | None -> raise Cannot_rename_root
 end

--- a/zarr/src/node.mli
+++ b/zarr/src/node.mli
@@ -13,6 +13,9 @@
 exception Node_invariant
 (** raised when a node's invariants are violated. *)
 
+exception Cannot_rename_root
+(** raised when attempting to rename a root node. *)
+
 module GroupNode : sig
   type t
   (** The type of a Group node. *)
@@ -72,6 +75,14 @@ module GroupNode : sig
 
   val pp : Format.formatter -> t -> unit
   (** [pp fmt t] pretty prints a node type value. *)
+
+  val rename : t -> string -> t
+  (** [rename t s] returns a new group node with all properties of [t]
+      but with its name changed to [s].
+
+      @raise Node_invariant if [s] is invalid name.
+      @raise Renaming_root if [t] is a root node.*)
+
 end
 
 module ArrayNode : sig
@@ -126,4 +137,11 @@ module ArrayNode : sig
 
   val pp : Format.formatter -> t -> unit
   (** [pp fmt t] pretty prints a node type value. *)
+
+  val rename : t -> string -> t
+  (** [rename t s] returns a new node with all properties of [t]
+      but with its name changed to [s].
+
+      @raise Node_invariant if [s] is invalid name.
+      @raise Renaming_root if [t] is a root node.*)
 end

--- a/zarr/src/storage/storage.ml
+++ b/zarr/src/storage/storage.ml
@@ -202,4 +202,16 @@ module Make (Io : Types.IO) = struct
           | true -> erase t key
           | false -> Deferred.return_unit) ArraySet.(elements @@ diff s s')
     in set t mkey @@ ArrayMetadata.(encode @@ update_shape meta nshape)
+
+  let rename_array t node str =
+    let key = ArrayNode.to_key node in
+    array_exists t node >>= function
+    | false -> raise @@ Key_not_found key
+    | true -> rename t key ArrayNode.(rename node str |> to_key)
+
+  let rename_group t node str =
+    let key = GroupNode.to_key node in
+    group_exists t node >>= function
+    | false -> raise @@ Key_not_found key
+    | true -> rename t key GroupNode.(rename node str |> to_key)
 end

--- a/zarr/src/storage/storage_intf.ml
+++ b/zarr/src/storage/storage_intf.ml
@@ -133,6 +133,20 @@ module type STORE = sig
         if [shape] does not have the same dimensions as [n]'s shape.
       @raise Key_not_found
         if node [n] is not a member of store [t]. *)
+
+  val rename_group : t -> GroupNode.t -> string -> unit Deferred.t
+  (** [rename t g name] changes the name of group node [g] in store [t] to [name].
+
+      @raise Key_not_found if [g] is not a member of store [t].
+      @raise Renaming_root if [g] is the store's root node.
+      @raise Node_invariant if [name] is an invalid node name.*)
+
+  val rename_array : t -> ArrayNode.t -> string -> unit Deferred.t
+  (** [rename t n name] changes the name of array node [n] in store [t] to [name].
+
+      @raise Key_not_found if [g] is not a member of store [t].
+      @raise Renaming_root if [g] is the store's root node.
+      @raise Node_invariant if [name] is an invalid node name.*)
 end
 
 module type Interface = sig

--- a/zarr/src/types.ml
+++ b/zarr/src/types.ml
@@ -52,4 +52,5 @@ module type IO = sig
   val list : t -> key list Deferred.t
   val list_dir : t -> key -> (key list * prefix list) Deferred.t
   val is_member : t -> key -> bool Deferred.t
+  val rename : t -> key -> key -> unit Deferred.t
 end

--- a/zarr/test/test_node.ml
+++ b/zarr/test/test_node.ml
@@ -78,6 +78,16 @@ let group_node = [
     false @@
     GroupNode.is_child_group GroupNode.root GroupNode.root;
 
+  (* rename tests *)
+  assert_raises
+    (Zarr.Node.Cannot_rename_root)
+    (fun () -> GroupNode.rename GroupNode.root "somename");
+  assert_raises
+    (Zarr.Node.Node_invariant)
+    (fun () -> GroupNode.rename n "?illegal/");
+  let n' = GroupNode.rename n "newname" in
+  assert_bool "" GroupNode.(name n' <> name n);
+
   (* stringify tests *)
   assert_equal
     ~printer:Fun.id "" @@ GroupNode.to_key GroupNode.root;
@@ -149,6 +159,16 @@ let array_node = [
   let m = ArrayNode.of_path "/some" in
   assert_equal false ArrayNode.(is_parent root GroupNode.root);
   assert_equal true @@ ArrayNode.is_parent m GroupNode.root;
+
+  (* rename tests *)
+  assert_raises
+    (Zarr.Node.Cannot_rename_root)
+    (fun () -> ArrayNode.rename ArrayNode.root "somename");
+  assert_raises
+    (Zarr.Node.Node_invariant)
+    (fun () -> ArrayNode.rename n "?illegal/");
+  let n' = ArrayNode.rename n "newname" in
+  assert_bool "" ArrayNode.(name n' <> name n);
 
   (* stringify tests *)
   assert_equal


### PR DESCRIPTION
This adds the ability to rename either a group or array node in a Zarr hierarchy.