### PR TITLE
Ensure coordinates in transposed array are permuted.

### DIFF
--- a/zarr/src/codecs/array_to_array.ml
+++ b/zarr/src/codecs/array_to_array.ml
@@ -16,12 +16,12 @@ module TransposeCodec = struct
 
   (* See https://github.com/owlbarn/owl/issues/671#issuecomment-2241761001 *)
 
-  let encode o x = Ndarray.transpose ~axis:o x
+  let encode o x = Ndarray.transpose ~axes:o x
 
   let decode o x =
     let inv_order = Array.(make (length o) 0) in
     Array.iteri (fun i x -> inv_order.(x) <- i) o;
-    Ndarray.transpose ~axis:inv_order x
+    Ndarray.transpose ~axes:inv_order x
 
   let to_yojson order =
     let o = `List (Array.to_list @@ Array.map (fun x -> `Int x) order) in

--- a/zarr/src/codecs/array_to_bytes.ml
+++ b/zarr/src/codecs/array_to_bytes.ml
@@ -180,7 +180,7 @@ end = struct
     = fun t x ->
     let y = match t.a2a with
       | [] -> x
-      | `Transpose o :: _ -> Ndarray.transpose ~axis:o x in
+      | `Transpose o :: _ -> Ndarray.transpose ~axes:o x in
     let z = match t.a2b with
       | `Bytes e -> BytesCodec.encode y e in
     List.fold_left BytesToBytes.encode z (t.b2b :> bytestobytes list)
@@ -237,7 +237,7 @@ end = struct
     | `Transpose o :: _ ->
       let inv_order = Array.(make (length o) 0) in
       Array.iteri (fun i x -> inv_order.(x) <- i) o;
-      Ndarray.transpose ~axis:inv_order arr
+      Ndarray.transpose ~axes:inv_order arr
 
   let index_size index_chain cps =
     encoded_size (16 * Util.prod cps) index_chain

--- a/zarr/src/ndarray.mli
+++ b/zarr/src/ndarray.mli
@@ -79,7 +79,7 @@ val iter : ('a -> unit) -> 'a t -> unit
 val equal : 'a t -> 'a t -> bool
 (** [equal x y] is [true] iff [x] and [y] are equal, else [false].*)
 
-val transpose : ?axis:int array -> 'a t -> 'a t
+val transpose : ?axes:int array -> 'a t -> 'a t
 (** [transpose o x] permutes the axes of [x] according to [o].*)
 
 val to_bigarray : 'a t -> ('a, 'b) Bigarray.kind -> ('a, 'b, Bigarray.c_layout) Bigarray.Genarray.t

--- a/zarr/src/storage/memory.ml
+++ b/zarr/src/storage/memory.ml
@@ -54,9 +54,9 @@ module Make (Deferred : Types.Deferred) = struct
     let f = if append || ov = String.empty then
       fun acc (_, v) -> acc ^ v else
       fun acc (rs, v) ->
-        let s = Bytes.of_string acc in
+        let s = Bytes.unsafe_of_string acc in
         Bytes.blit_string v 0 s rs String.(length v);
-        Bytes.to_string s
+        Bytes.unsafe_to_string s
     in
     let m' = M.add key (List.fold_left f ov rv) m in
     if Atomic.compare_and_set t m m'

--- a/zarr/test/test_ndarray.ml
+++ b/zarr/test/test_ndarray.ml
@@ -66,6 +66,22 @@ let tests = [
   assert_equal ~printer:Fun.id "????" (Buffer.contents buf);
 )
 ;
+"test transpose functionality" >:: (fun _ ->
+  let shape = [|2; 1; 3|]
+  and axes = [|2; 0; 1|] 
+  and a = [|0.15458236; 0.94363903; 0.63893012; 0.29207497; 0.31390295; 0.42341309|] in
+  let x = M.of_array Float32 shape a in
+  let x' = M.transpose ~axes x in
+  assert_equal ~printer:[%show: int array] [|3; 2; 1|] (M.shape x');
+  (* test if a particular value is transposed correctly. *)
+  assert_equal ~printer:string_of_float (M.get x [|1; 0; 2|]) (M.get x' [|2; 1; 0|]);
+  let flat_exp = [|0.15458236; 0.29207497; 0.94363903; 0.31390295; 0.63893012; 0.42341309|] in
+  assert_equal ~printer:[%show: float array] flat_exp (M.to_array x');
+  let inv_order = Array.(make (length axes) 0) in
+  Array.iteri (fun i x -> inv_order.(x) <- i) axes;
+  assert_equal true @@ M.equal x (M.transpose ~axes:inv_order x')
+)
+;
 "test interop with bigarrays" >:: (fun _ ->
   let s = [|2; 5; 3|] in
   let module B = Bigarray in


### PR DESCRIPTION
This ensures the coordinates in the transposed array are correctly
rearranged based to the permutation array and new strides. Previously
this was silently not done and thus the actual values inside the
transposed array where not in their correct n-dimensional index.