### PR TITLE
Streamline code generation of `MemoryStore/ZipStore`.

### DIFF
--- a/zarr-eio/src/storage.ml
+++ b/zarr-eio/src/storage.ml
@@ -1,14 +1,5 @@
-module MemoryStore = struct
-  module M = Zarr.Memory.Make(Deferred)
-  include Zarr.Storage.Make(M)
-  let create = M.create
-end
-
-module ZipStore = struct
-  module Z = Zarr.Zip.Make(Deferred)
-  include Zarr.Storage.Make(Z)
-  let with_open = Z.with_open
-end
+module ZipStore = Zarr.Zip.Make(Deferred)
+module MemoryStore = Zarr.Memory.Make(Deferred)
 
 module FilesystemStore = struct
   module FS = struct

--- a/zarr-eio/src/storage.ml
+++ b/zarr-eio/src/storage.ml
@@ -2,7 +2,7 @@ module ZipStore = Zarr.Zip.Make(Deferred)
 module MemoryStore = Zarr.Memory.Make(Deferred)
 
 module FilesystemStore = struct
-  module FS = struct
+  module IO = struct
     module Deferred = Deferred
 
     type t = {root : Eio.Fs.dir_ty Eio.Path.t; perm : Eio.File.Unix_perm.t}
@@ -102,17 +102,15 @@ module FilesystemStore = struct
     let rename t k k' = Eio.Path.rename (key_to_fspath t k) (key_to_fspath t k')
   end
 
-  module U = Zarr.Util
-
   let create ?(perm=0o700) ~env dirname =
-    U.create_parent_dir dirname perm;
+    Zarr.Util.create_parent_dir dirname perm;
     Sys.mkdir dirname perm;
-    FS.{root = Eio.Path.(Eio.Stdenv.fs env / U.sanitize_dir dirname); perm}
+    IO.{root = Eio.Path.(Eio.Stdenv.fs env / Zarr.Util.sanitize_dir dirname); perm}
 
   let open_store ?(perm=0o700) ~env dirname =
     if Sys.is_directory dirname
-    then FS.{root = Eio.Path.(Eio.Stdenv.fs env / U.sanitize_dir dirname); perm}
+    then IO.{root = Eio.Path.(Eio.Stdenv.fs env / Zarr.Util.sanitize_dir dirname); perm}
     else raise (Zarr.Storage.Not_a_filesystem_store dirname)
 
-  include Zarr.Storage.Make(FS)
+  include Zarr.Storage.Make(IO)
 end

--- a/zarr-eio/src/storage.mli
+++ b/zarr-eio/src/storage.mli
@@ -1,12 +1,11 @@
-(** An in-memory storage backend for Zarr V3 hierarchy. *)
-module MemoryStore : sig include Zarr.Memory.S with type 'a Deferred.t = 'a end
+(** An Eio-aware in-memory storage backend for Zarr v3 hierarchy. *)
+module MemoryStore : Zarr.Memory.S with type 'a Deferred.t = 'a
 
 (** An Eio-aware Zip file storage backend for a Zarr v3 hierarchy. *)
-module ZipStore : sig include Zarr.Zip.S with type 'a Deferred.t = 'a end
+module ZipStore : Zarr.Zip.S with type 'a Deferred.t = 'a
 
+(** An Eio-aware local filesystem storage backend for a Zarr v3 hierarchy. *)
 module FilesystemStore : sig
-  (** A local filesystem storage backend for a Zarr V3 hierarchy. *)
-
   include Zarr.Storage.STORE with type 'a Deferred.t = 'a
 
   val create : ?perm:Eio.File.Unix_perm.t -> env:<fs : Eio.Fs.dir_ty Eio.Path.t; ..> -> string -> t

--- a/zarr-lwt/src/storage.ml
+++ b/zarr-lwt/src/storage.ml
@@ -2,7 +2,7 @@ module ZipStore = Zarr.Zip.Make(Deferred)
 module MemoryStore = Zarr.Memory.Make(Deferred)
 
 module FilesystemStore = struct
-  module FS = struct
+  module IO = struct
     module Deferred = Deferred
     open Deferred.Infix
     open Deferred.Syntax
@@ -126,17 +126,15 @@ module FilesystemStore = struct
     let rename t k k' = Lwt_unix.rename (key_to_fspath t k) (key_to_fspath t k')
   end
 
-  module U = Zarr.Util
-
   let create ?(perm=0o700) dirname =
-    U.create_parent_dir dirname perm;
+    Zarr.Util.create_parent_dir dirname perm;
     Sys.mkdir dirname perm;
-    FS.{dirname = U.sanitize_dir dirname; perm}
+    IO.{dirname = Zarr.Util.sanitize_dir dirname; perm}
 
   let open_store ?(perm=0o700) dirname =
     if Sys.is_directory dirname
-    then FS.{dirname = U.sanitize_dir dirname; perm}
+    then IO.{dirname = Zarr.Util.sanitize_dir dirname; perm}
     else raise (Zarr.Storage.Not_a_filesystem_store dirname)
 
-  include Zarr.Storage.Make(FS)
+  include Zarr.Storage.Make(IO)
 end

--- a/zarr-lwt/src/storage.ml
+++ b/zarr-lwt/src/storage.ml
@@ -1,14 +1,5 @@
-module MemoryStore = struct
-  module M = Zarr.Memory.Make(Deferred)
-  include Zarr.Storage.Make(M)
-  let create = M.create
-end
-
-module ZipStore = struct
-  module Z = Zarr.Zip.Make(Deferred)
-  include Zarr.Storage.Make(Z)
-  let with_open = Z.with_open
-end
+module ZipStore = Zarr.Zip.Make(Deferred)
+module MemoryStore = Zarr.Memory.Make(Deferred)
 
 module FilesystemStore = struct
   module FS = struct

--- a/zarr-lwt/src/storage.mli
+++ b/zarr-lwt/src/storage.mli
@@ -1,12 +1,11 @@
-(** An in-memory storage backend for Zarr V3 hierarchy. *)
+(** An Lwt-aware in-memory storage backend for Zarr v3 hierarchy. *)
 module MemoryStore : sig include Zarr.Memory.S with type 'a Deferred.t = 'a Lwt.t end
 
 (** An Lwt-aware Zip file storage backend for a Zarr v3 hierarchy. *)
-module ZipStore : sig include Zarr.Zip.S with type 'a Deferred.t = 'a Lwt.t end
+module ZipStore : Zarr.Zip.S with type 'a Deferred.t = 'a Lwt.t
 
+(** An Lwt-aware local filesystem storage backend for a Zarr V3 hierarchy. *)
 module FilesystemStore : sig
-  (** A local filesystem storage backend for a Zarr V3 hierarchy. *)
-
   include Zarr.Storage.STORE with type 'a Deferred.t = 'a Lwt.t
 
   val create : ?perm:Unix.file_perm -> string -> t

--- a/zarr-sync/src/storage.ml
+++ b/zarr-sync/src/storage.ml
@@ -2,7 +2,7 @@ module ZipStore = Zarr.Zip.Make(Deferred)
 module MemoryStore = Zarr.Memory.Make(Deferred)
 
 module FilesystemStore = struct
-  module F = struct
+  module IO = struct
     module Deferred = Deferred
 
     type t = {dirname : string; perm : Unix.file_perm}
@@ -85,17 +85,15 @@ module FilesystemStore = struct
     let rename t k k' = Sys.rename (key_to_fspath t k) (key_to_fspath t k')
   end
 
-  module U = Zarr.Util
-
   let create ?(perm=0o700) dirname =
-    U.create_parent_dir dirname perm;
+    Zarr.Util.create_parent_dir dirname perm;
     Sys.mkdir dirname perm;
-    F.{dirname = U.sanitize_dir dirname; perm}
+    IO.{dirname = Zarr.Util.sanitize_dir dirname; perm}
 
   let open_store ?(perm=0o700) dirname =
     if Sys.is_directory dirname
-    then F.{dirname = U.sanitize_dir dirname; perm}
+    then IO.{dirname = Zarr.Util.sanitize_dir dirname; perm}
     else raise (Zarr.Storage.Not_a_filesystem_store dirname)
 
-  include Zarr.Storage.Make(F)
+  include Zarr.Storage.Make(IO)
 end

--- a/zarr-sync/src/storage.ml
+++ b/zarr-sync/src/storage.ml
@@ -1,14 +1,5 @@
-module MemoryStore = struct
-  module M = Zarr.Memory.Make(Deferred)
-  include Zarr.Storage.Make(M)
-  let create = M.create
-end
-
-module ZipStore = struct
-  module Z = Zarr.Zip.Make(Deferred)
-  include Zarr.Storage.Make(Z)
-  let with_open = Z.with_open
-end
+module ZipStore = Zarr.Zip.Make(Deferred)
+module MemoryStore = Zarr.Memory.Make(Deferred)
 
 module FilesystemStore = struct
   module F = struct

--- a/zarr-sync/src/storage.mli
+++ b/zarr-sync/src/storage.mli
@@ -1,12 +1,11 @@
-(** An in-memory storage backend for Zarr V3 hierarchy. *)
-module MemoryStore : sig include Zarr.Memory.S with type 'a Deferred.t = 'a end
+(** A blocking I/O in-memory storage backend for Zarr v3 hierarchy. *)
+module MemoryStore : Zarr.Memory.S with type 'a Deferred.t = 'a
 
 (** A blocking I/O Zip file storage backend for a Zarr v3 hierarchy. *)
-module ZipStore : sig include Zarr.Zip.S with type 'a Deferred.t = 'a end
+module ZipStore : Zarr.Zip.S with type 'a Deferred.t = 'a
 
+(** A blocking I/O local filesystem storage backend for a Zarr v3 hierarchy. *)
 module FilesystemStore : sig
-  (** A local filesystem storage backend for a Zarr V3 hierarchy. *)
-
   include Zarr.Storage.STORE with type 'a Deferred.t = 'a
 
   val create : ?perm:Unix.file_perm -> string -> t

--- a/zarr/src/storage/memory.ml
+++ b/zarr/src/storage/memory.ml
@@ -4,90 +4,107 @@ module type S = sig
   (** [create ()] returns a new In-memory Zarr store type.*)
 end
 
-module Make (Deferred : Types.Deferred) = struct
-  module M = Map.Make(String)
-  module Deferred = Deferred
+module Make (Deferred : Types.Deferred) : S with type 'a Deferred.t = 'a Deferred.t = struct
   open Deferred.Syntax
 
-  type t = string M.t Atomic.t
+  module M = Map.Make(String)
 
-  let create : unit -> t = fun () -> Atomic.make M.empty
+  module IO = struct
+    module Deferred = Deferred
 
-  let get t key = match M.find_opt key (Atomic.get (t : t)) with
-    | None -> raise (Storage.Key_not_found key)
-    | Some v -> Deferred.return v
+    type t = string M.t Atomic.t
 
-  let rec set t key value =
-    let m = Atomic.get (t : t) in
-    if Atomic.compare_and_set t m (M.add key value m)
-    then Deferred.return_unit else set t key value 
+    let get : t -> string -> string Deferred.t = fun t key ->
+      match M.find_opt key (Atomic.get t) with
+      | None -> raise (Storage.Key_not_found key)
+      | Some v -> Deferred.return v
 
-  let list t =
-    Deferred.return @@ M.fold (fun k _ acc -> k :: acc) (Atomic.get (t : t)) []
+    let rec set : t -> string -> string -> unit Deferred.t = fun t key value ->
+      let m = Atomic.get t in
+      if Atomic.compare_and_set t m (M.add key value m)
+      then Deferred.return_unit else set t key value 
 
-  let is_member t key = Deferred.return @@ M.mem key (Atomic.get (t : t))
+    let list : t -> string list Deferred.t = fun t ->
+      let m = Atomic.get t in
+      Deferred.return @@ M.fold (fun k _ acc -> k :: acc) m []
 
-  let rec erase t key =
-    let m = Atomic.get (t : t) in
-    let m' = M.update key (Fun.const None) m in
-    if Atomic.compare_and_set t m m'
-    then Deferred.return_unit else erase t key
+    let is_member : t -> string -> bool Deferred.t = fun t key ->
+      let m = Atomic.get t in
+      Deferred.return (M.mem key m)
 
-  let size t key =
-    let binding_opt = M.find_opt key (Atomic.get (t : t)) in
-    Deferred.return (Option.fold ~none:0 ~some:String.length binding_opt)
+    let rec erase : t -> string -> unit Deferred.t = fun t key ->
+      let m = Atomic.get t in
+      let m' = M.update key (Fun.const None) m in
+      if Atomic.compare_and_set t m m'
+      then Deferred.return_unit else erase t key
 
-  let rec erase_prefix t prefix =
-    let pred ~prefix k v = if String.starts_with ~prefix k then None else Some v in
-    let m = Atomic.get (t : t) in
-    let m' = M.filter_map (pred ~prefix) m in
-    if Atomic.compare_and_set t m m'
-    then Deferred.return_unit else erase_prefix t prefix
+    let size : t -> string -> int Deferred.t = fun t key ->
+      match M.find_opt key (Atomic.get t) with
+      | None -> Deferred.return 0
+      | Some e -> Deferred.return (String.length e)
 
-  let get_partial_values t key ranges =
-    let read_range ~data ~size (ofs, len) = match len with
-      | Some l -> String.sub data ofs l
-      | None -> String.sub data ofs (size - ofs)
-    in
-    let+ data = get t key in
-    let size = String.length data in
-    List.map (read_range ~data ~size) ranges
+    let rec erase_prefix : t -> string -> unit Deferred.t = fun t prefix ->
+      let pred ~prefix k v = if String.starts_with ~prefix k then None else Some v in
+      let m = Atomic.get t in
+      let m' = M.filter_map (pred ~prefix) m in
+      if Atomic.compare_and_set t m m'
+      then Deferred.return_unit else erase_prefix t prefix
 
-  let rec set_partial_values t key ?(append=false) rv =
-    let m = Atomic.get (t : t) in
-    let ov = Option.fold ~none:String.empty ~some:Fun.id (M.find_opt key m) in
-    let f = if append || ov = String.empty then
-      fun acc (_, v) -> acc ^ v else
-      fun acc (rs, v) ->
-        let s = Bytes.unsafe_of_string acc in
-        Bytes.blit_string v 0 s rs String.(length v);
-        Bytes.unsafe_to_string s
-    in
-    let m' = M.add key (List.fold_left f ov rv) m in
-    if Atomic.compare_and_set t m m'
-    then Deferred.return_unit else set_partial_values t key ~append rv
+    let get_partial_values :
+      t -> string -> (int * int option) list -> string list Deferred.t
+      = fun t key ranges ->
+      let read_range ~data ~size (ofs, len) = match len with
+        | Some l -> String.sub data ofs l
+        | None -> String.sub data ofs (size - ofs)
+      in
+      let+ data = get t key in
+      let size = String.length data in
+      List.map (read_range ~data ~size) ranges
 
-  let list_dir t prefix =
-    let module S = Set.Make(String) in
-    let m = Atomic.get (t : t) in
-    let add ~size ~prefix key _ ((l, r) as acc) =
-      if not (String.starts_with ~prefix key) then acc else
-      if not (String.contains_from key size '/') then key :: l, r else
-      l, S.add String.(sub key 0 @@ 1 + index_from key size '/') r
-    in
-    let size = String.length prefix in
-    let keys, prefixes = M.fold (add ~prefix ~size) m ([], S.empty) in
-    Deferred.return (keys, S.elements prefixes)
+    let rec set_partial_values :
+      t -> string -> ?append:bool -> (int * string) list -> unit Deferred.t
+      = fun t key ?(append=false) rv ->
+      let m = Atomic.get t in
+      let ov = Option.fold ~none:String.empty ~some:Fun.id (M.find_opt key m) in
+      let f = if append || ov = String.empty then
+        fun acc (_, v) -> acc ^ v else
+        fun acc (rs, v) ->
+          let s = Bytes.unsafe_of_string acc in
+          Bytes.blit_string v 0 s rs String.(length v);
+          Bytes.unsafe_to_string s
+      in
+      let m' = M.add key (List.fold_left f ov rv) m in
+      if Atomic.compare_and_set t m m'
+      then Deferred.return_unit else set_partial_values t key ~append rv
 
-  let rec rename t prefix new_prefix =
-    let add ~prefix ~new_prefix k v acc =
-      if not (String.starts_with ~prefix k) then M.add k v acc else
-      let l = String.length prefix in
-      let k' = new_prefix ^ String.sub k l (String.length k - l) in
-      M.add k' v acc
-    in
-    let m = Atomic.get (t : t) in
-    let m' = M.fold (add ~prefix ~new_prefix) m M.empty in
-    if Atomic.compare_and_set t m m'
-    then Deferred.return_unit else rename t prefix new_prefix
+    let list_dir : t -> string -> (string list * string list) Deferred.t = fun t prefix ->
+      let module S = Set.Make(String) in
+      let add ~size ~prefix key _ ((l, r) as acc) =
+        if not (String.starts_with ~prefix key) then acc else
+        if not (String.contains_from key size '/') then key :: l, r else
+        l, S.add String.(sub key 0 @@ 1 + index_from key size '/') r
+      in
+      let size = String.length prefix in
+      let m = Atomic.get t in
+      let keys, prefixes = M.fold (add ~prefix ~size) m ([], S.empty) in
+      Deferred.return (keys, S.elements prefixes)
+
+    let rec rename :
+      t -> string -> string -> unit Deferred.t
+      = fun t prefix new_prefix ->
+      let add ~prefix ~new_prefix k v acc =
+        if not (String.starts_with ~prefix k) then M.add k v acc else
+        let l = String.length prefix in
+        let k' = new_prefix ^ String.sub k l (String.length k - l) in
+        M.add k' v acc
+      in
+      let m = Atomic.get t in
+      let m' = M.fold (add ~prefix ~new_prefix) m M.empty in
+      if Atomic.compare_and_set t m m'
+      then Deferred.return_unit else rename t prefix new_prefix
+  end
+
+  let create : unit -> IO.t = fun () -> Atomic.make M.empty
+
+  include Storage.Make(IO)
 end

--- a/zarr/src/storage/zip.ml
+++ b/zarr/src/storage/zip.ml
@@ -28,11 +28,8 @@ module type S = sig
       } *)
 end
 
-module Make (Deferred : Types.Deferred) = struct
-  module Deferred = Deferred
+module Make (Deferred : Types.Deferred) : S with type 'a Deferred.t = 'a Deferred.t = struct
   open Deferred.Syntax
-
-  type t = {ic : Zipc.t Atomic.t; level : Zipc_deflate.level}
 
   let fold_kind ~dir ~file = function
     | Zipc.Member.Dir -> dir
@@ -40,13 +37,136 @@ module Make (Deferred : Types.Deferred) = struct
 
   let fold_result ~ok res = Result.fold ~error:failwith ~ok res
 
+  module IO = struct
+    module Deferred = Deferred
+
+    type t = {ic : Zipc.t Atomic.t; level : Zipc_deflate.level}
+
+    let is_member t key =
+      let z = Atomic.get t.ic in
+      Deferred.return (Zipc.mem key z)
+
+    let size t key =
+      let decompressed_size = function
+        | None -> 0
+        | Some m ->
+          let entry_kind = Zipc.Member.kind m in
+          fold_kind ~dir:0 ~file:Zipc.File.decompressed_size entry_kind
+      in
+      let z = Atomic.get t.ic in
+      Deferred.return (decompressed_size @@ Zipc.find key z)
+
+    let get t key =
+      let to_string f = fold_result ~ok:Fun.id (Zipc.File.to_binary_string f) in
+      let decompressed_value = function
+        | None -> raise (Storage.Key_not_found key)
+        | Some m ->
+          let entry_kind = Zipc.Member.kind m in
+          fold_kind ~dir:String.empty ~file:to_string entry_kind
+      in
+      let z = Atomic.get t.ic in
+      Deferred.return (decompressed_value @@ Zipc.find key z)
+
+    let get_partial_values t key ranges =
+      let read_range ~data ~size (ofs, len) = match len with
+        | None -> String.sub data ofs (size - ofs)
+        | Some l -> String.sub data ofs l
+      in
+      let+ data = get t key in
+      let size = String.length data in
+      List.map (read_range ~data ~size) ranges
+
+    let list t =
+      let accumulate_path m acc = Zipc.Member.path m :: acc in
+      let z = Atomic.get t.ic in
+      Deferred.return (Zipc.fold accumulate_path z [])
+
+    let list_dir t prefix =
+      let module S = Set.Make(String) in
+      let accumulate ~prefix m ((l, r) as acc) =
+        let key = Zipc.Member.path m in
+        if not (String.starts_with ~prefix key) then acc else
+        let n = String.length prefix in
+        if not (String.contains_from key n '/') then key :: l, r else
+        l, S.add String.(sub key 0 @@ 1 + index_from key n '/') r
+      in
+      let z = Atomic.get t.ic in 
+      let ks, ps = Zipc.fold (accumulate ~prefix) z ([], S.empty) in
+      Deferred.return (ks, S.elements ps)
+
+    let rec set t key value =
+      let res = Zipc.File.deflate_of_binary_string ~level:t.level value in
+      let f = Zipc.Member.File (fold_result ~ok:Fun.id res) in
+      let m = fold_result ~ok:Fun.id Zipc.Member.(make ~path:key f) in
+      let z = Atomic.get t.ic in
+      if Atomic.compare_and_set t.ic z (Zipc.add m z)
+      then Deferred.return_unit else set t key value
+
+    let rec set_partial_values t key ?(append=false) rv =
+      let to_string f = fold_result ~ok:Fun.id (Zipc.File.to_binary_string f) in
+      let empty =
+        let res = Zipc.File.deflate_of_binary_string ~level:t.level String.empty in
+        let res' = Zipc.Member.File (fold_result ~ok:Fun.id res) in
+        fold_result ~ok:Fun.id Zipc.Member.(make ~path:key res')
+      in
+      let z = Atomic.get t.ic in
+      let mem = Option.fold ~none:empty ~some:Fun.id (Zipc.find key z) in
+      let ov = fold_kind ~dir:String.empty ~file:to_string (Zipc.Member.kind mem) in
+      let f = if append || ov = String.empty then
+        fun acc (_, v) -> acc ^ v else
+        fun acc (rs, v) ->
+          let s = Bytes.unsafe_of_string acc in
+          Bytes.blit_string v 0 s rs String.(length v);
+          Bytes.unsafe_to_string s
+      in
+      let ov' = List.fold_left f ov rv in
+      let res = Zipc.File.deflate_of_binary_string ~level:t.level ov' in
+      let file = Zipc.Member.File (fold_result ~ok:Fun.id res) in
+      let m = fold_result ~ok:Fun.id Zipc.Member.(make ~path:key file) in
+      if Atomic.compare_and_set t.ic z (Zipc.add m z)
+      then Deferred.return_unit else set_partial_values t key ~append rv
+
+    let rec erase t key =
+      let z = Atomic.get t.ic in
+      if Atomic.compare_and_set t.ic z (Zipc.remove key z)
+      then Deferred.return_unit else erase t key
+
+    let rec erase_prefix t prefix =
+      let accumulate ~prefix m acc =
+        if String.starts_with ~prefix (Zipc.Member.path m)
+        then acc else Zipc.add m acc
+      in
+      let z = Atomic.get t.ic in
+      let z' = Zipc.fold (accumulate ~prefix) z Zipc.empty in
+      if Atomic.compare_and_set t.ic z z'
+      then Deferred.return_unit else erase_prefix t prefix
+
+    (* Adapted from: https://github.com/dbuenzli/zipc/issues/8#issuecomment-2392417890 *)
+    let rec rename t prefix new_prefix =
+      let accumulate ~prefix ~new_prefix m acc =
+        let path = Zipc.Member.path m in
+        if not (String.starts_with ~prefix path) then Zipc.add m acc else
+        let l = String.length prefix in
+        let path = new_prefix ^ String.sub path l (String.length path - l) in
+        let mtime = Zipc.Member.mtime m in
+        let mode = Zipc.Member.mode m in
+        let kind = Zipc.Member.kind m in
+        let m' = Zipc.Member.make ~mtime ~mode ~path kind in
+        Zipc.add (fold_result ~ok:Fun.id m') acc
+      in
+      let z = Atomic.get t.ic in
+      let z' = Zipc.fold (accumulate ~prefix ~new_prefix) z Zipc.empty in
+      if Atomic.compare_and_set t.ic z z'
+      then Deferred.return_unit else rename t prefix new_prefix
+  end
+
   let with_open ?(level=`Default) ?(perm=0o700) mode path f =
     let write_to_disk ~perm ~path str =
       let write ~str oc = Out_channel.output_string oc str; flush oc in
       let flags = [Open_wronly; Open_trunc; Open_creat] in
       Out_channel.with_open_gen flags perm path (write ~str)
     in
-    let make z = {ic = Atomic.make z; level} in
+    let make z = IO.{ic = Atomic.make z; level} in
     let x = if not (Sys.file_exists path) then make Zipc.empty else
       let s = In_channel.(with_open_bin path input_all) in
       fold_result ~ok:make (Zipc.of_binary_string s)
@@ -59,117 +179,5 @@ module Make (Deferred : Types.Deferred) = struct
       fold_result ~ok:(write_to_disk ~perm ~path) str;
       out
 
-  let is_member t key =
-    let z = Atomic.get t.ic in
-    Deferred.return (Zipc.mem key z)
-
-  let size t key =
-    let decompressed_size = function
-      | Some m -> fold_kind ~dir:0 ~file:Zipc.File.decompressed_size (Zipc.Member.kind m)
-      | None -> 0
-    in
-    let z = Atomic.get t.ic in
-    let entry_opt = Zipc.find key z in
-    Deferred.return (decompressed_size entry_opt)
-
-  let get t key =
-    let to_string f = fold_result ~ok:Fun.id (Zipc.File.to_binary_string f) in
-    let decompressed_value = function
-      | Some m -> fold_kind ~dir:String.empty ~file:to_string (Zipc.Member.kind m)
-      | None -> raise (Storage.Key_not_found key)
-    in
-    let z = Atomic.get t.ic in
-    let entry_opt = Zipc.find key z in
-    Deferred.return (decompressed_value entry_opt)
-
-  let get_partial_values t key ranges =
-    let read_range ~data ~size (ofs, len) = match len with
-      | None -> String.sub data ofs (size - ofs)
-      | Some l -> String.sub data ofs l
-    in
-    let+ data = get t key in
-    let size = String.length data in
-    List.map (read_range ~data ~size) ranges
-
-  let list t =
-    let z = Atomic.get t.ic in
-    Deferred.return (Zipc.fold (fun m acc -> Zipc.Member.path m :: acc) z [])
-
-  let list_dir t prefix =
-    let module S = Set.Make(String) in
-    let accumulate ~prefix m ((l, r) as acc) =
-      let key = Zipc.Member.path m in
-      if not (String.starts_with ~prefix key) then acc else
-      let n = String.length prefix in
-      if not (String.contains_from key n '/') then key :: l, r else
-      l, S.add String.(sub key 0 @@ 1 + index_from key n '/') r
-    in
-    let z = Atomic.get t.ic in 
-    let ks, ps = Zipc.fold (accumulate ~prefix) z ([], S.empty) in
-    Deferred.return (ks, S.elements ps)
-
-  let rec set t key value =
-    let res = Zipc.File.deflate_of_binary_string ~level:t.level value in
-    let f = Zipc.Member.File (fold_result ~ok:Fun.id res) in
-    let m = fold_result ~ok:Fun.id Zipc.Member.(make ~path:key f) in
-    let z = Atomic.get t.ic in
-    if Atomic.compare_and_set t.ic z (Zipc.add m z)
-    then Deferred.return_unit else set t key value
-
-  let rec set_partial_values t key ?(append=false) rv =
-    let to_string f = fold_result ~ok:Fun.id (Zipc.File.to_binary_string f) in
-    let empty =
-      let res = Zipc.File.deflate_of_binary_string ~level:t.level String.empty in
-      let res' = Zipc.Member.File (fold_result ~ok:Fun.id res) in
-      fold_result ~ok:Fun.id Zipc.Member.(make ~path:key res')
-    in
-    let z = Atomic.get t.ic in
-    let mem = Option.fold ~none:empty ~some:Fun.id (Zipc.find key z) in
-    let ov = fold_kind ~dir:String.empty ~file:to_string (Zipc.Member.kind mem) in
-    let f = if append || ov = String.empty then
-      fun acc (_, v) -> acc ^ v else
-      fun acc (rs, v) ->
-        let s = Bytes.unsafe_of_string acc in
-        Bytes.blit_string v 0 s rs String.(length v);
-        Bytes.unsafe_to_string s
-    in
-    let ov' = List.fold_left f ov rv in
-    let res = Zipc.File.deflate_of_binary_string ~level:t.level ov' in
-    let file = Zipc.Member.File (fold_result ~ok:Fun.id res) in
-    let m = fold_result ~ok:Fun.id Zipc.Member.(make ~path:key file) in
-    if Atomic.compare_and_set t.ic z (Zipc.add m z)
-    then Deferred.return_unit else set_partial_values t key ~append rv
-
-  let rec erase t key =
-    let z = Atomic.get t.ic in
-    if Atomic.compare_and_set t.ic z (Zipc.remove key z)
-    then Deferred.return_unit else erase t key
-
-  let rec erase_prefix t prefix =
-    let accumulate ~prefix m acc =
-      if String.starts_with ~prefix (Zipc.Member.path m)
-      then acc else Zipc.add m acc
-    in
-    let z = Atomic.get t.ic in
-    let z' = Zipc.fold (accumulate ~prefix) z Zipc.empty in
-    if Atomic.compare_and_set t.ic z z'
-    then Deferred.return_unit else erase_prefix t prefix
-
-  (* Adapted from: https://github.com/dbuenzli/zipc/issues/8#issuecomment-2392417890 *)
-  let rec rename t prefix new_prefix =
-    let accumulate ~prefix ~new_prefix m acc =
-      let path = Zipc.Member.path m in
-      if not (String.starts_with ~prefix path) then Zipc.add m acc else
-      let l = String.length prefix in
-      let path = new_prefix ^ String.sub path l (String.length path - l) in
-      let mtime = Zipc.Member.mtime m in
-      let mode = Zipc.Member.mode m in
-      let kind = Zipc.Member.kind m in
-      let m' = Zipc.Member.make ~mtime ~mode ~path kind in
-      Zipc.add (fold_result ~ok:Fun.id m') acc
-    in
-    let z = Atomic.get t.ic in
-    let z' = Zipc.fold (accumulate ~prefix ~new_prefix) z Zipc.empty in
-    if Atomic.compare_and_set t.ic z z'
-    then Deferred.return_unit else rename t prefix new_prefix
+  include Storage.Make(IO)
 end


### PR DESCRIPTION
Given a concurrency backend, make the generation of `MemoryStore` and `ZipStore` easy as writing a single line of code.