### PR TITLE
Add support for Amazon S3 bucket storage backend.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,12 +29,40 @@ jobs:
         local-packages:
           - zarr.opam
 
+    env:
+      AWS_ACCESS_KEY_ID: minioadmin
+      AWS_SECRET_ACCESS_KEY: minioadmin
+
+    services:
+      minio:
+        image: fclairamb/minio-github-actions
+        ports:
+          - 9000:9000
+
     name: Ocaml version - ${{ matrix.ocaml-compiler }} - ${{ matrix.os }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 2
+
+      - name: Setup Minio
+        run: |
+          mkdir ~/.aws
+          echo '[default]' > ~/.aws/credentials
+          echo 'aws_access_key_id = minioadmin' >> ~/.aws/credentials
+          echo 'aws_secret_access_key = minioadmin' >> ~/.aws/credentials
+          pip3 install minio
+          python3 - <<'EOF'
+          from minio import Minio
+          minio = Minio(
+             'localhost:9000',
+             access_key='minioadmin',
+             secret_key='minioadmin',
+             secure=False
+          )
+          minio.make_bucket('test-bucket-lwt', location='us-east-1')
+          EOF
 
       - name: setup-ocaml
         uses: ocaml/setup-ocaml@v3
@@ -45,7 +73,7 @@ jobs:
         run: |
           opam install --deps-only --with-test --with-doc --yes zarr
           opam install bytesrw conf-zlib conf-zstd --yes
-          opam install lwt --yes
+          opam install lwt aws-s3-lwt --yes
           opam exec -- dune build zarr zarr-sync zarr-lwt
       
       - name: setup ocaml-5-specific

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,8 @@ docs:
 .PHONY: view-docs
 view-docs: docs
 	chromium _build/default/_doc/_html/index.html 
+
+.PHONY: minio
+minio:
+	mkdir -p /tmp/minio/test-bucket-lwt
+	docker run --rm -it -p 9000:9000 -v /tmp/minio:/minio minio/minio:latest server /minio

--- a/dune-project
+++ b/dune-project
@@ -63,6 +63,7 @@
      (and (>= 4.14.0)))
    (zarr (= :version))
    (lwt (>= 2.5.1))
+   (aws-s3-lwt (>= 4.8.1))
    (odoc :with-doc)
    (ounit2 :with-test)
    (ppx_deriving :with-test)

--- a/zarr-lwt.opam
+++ b/zarr-lwt.opam
@@ -13,6 +13,7 @@ depends: [
   "ocaml" {>= "4.14.0"}
   "zarr" {= version}
   "lwt" {>= "2.5.1"}
+  "aws-s3-lwt" {>= "4.8.1"}
   "odoc" {with-doc}
   "ounit2" {with-test}
   "ppx_deriving" {with-test}

--- a/zarr-lwt/src/dune
+++ b/zarr-lwt/src/dune
@@ -3,6 +3,7 @@
  (public_name zarr-lwt)
  (libraries
    zarr
+   aws-s3-lwt
    lwt
    lwt.unix)
  (ocamlopt_flags

--- a/zarr-lwt/src/storage.mli
+++ b/zarr-lwt/src/storage.mli
@@ -20,3 +20,35 @@ module FilesystemStore : sig
 
       @raise Failure if [dir] is not a Zarr store path. *)
 end
+
+(** An Lwt-aware Amazon S3 bucket storage backend for a Zarr V3 hierarchy. *)
+module AmazonS3Store : sig
+  exception Request_failed of Aws_s3_lwt.S3.error
+
+  include Zarr.Storage.STORE with module Deferred = Deferred
+
+  val with_open :
+    ?scheme:[ `Http | `Https ] ->
+    ?inet:[ `V4 | `V6 ] ->
+    ?retries:int ->
+    region:Aws_s3.Region.t ->
+    bucket:string ->
+    profile:string ->
+    (t -> 'a Lwt.t) ->
+    'a Lwt.t
+  (** [with_open ~region ~bucket ~profile f] opens an S3 bucket store with
+      bucket name [bucket] at region [region] using credentials specified by
+      profile [profile]. The credentials are read locally from a [~/.aws/credentials]
+      file or from an IAM service if the profile or file is not available.
+      Function [f] is applied to the store's open handle and its output is
+      returned to the caller.
+
+      {ul 
+      {- [scheme] is the HTTP scheme to use when connecting to S3, and must be
+        one of [`Http | `Https]. Defaults to [`Http].}
+      {- [inet] is the IP version and must be one of [`V4 | `V6]. Defaults to [`V4].}
+      {- [retries] is the number of times to retry a request should it return an error.}
+      }
+
+      @raise Request_failed if an error occurs while sending a request to the S3 service. *)
+end


### PR DESCRIPTION
This adds support for using Amazon's S3 bucket as a storage backend via the `AwsStore` module. It is only implemented for the `Lwt` concurrency library at this time since the underlying AWS-S3 library does not yet have support for `Eio`.

addresses #55 