### PR TITLE
Rename `Deferred` to `IO` to reflect that its an I/O monad.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ open Zarr
 open Zarr.Codecs
 open Zarr.Indexing
 open Zarr_sync.Storage
-open Deferred.Infix  (* opens infix operators >>= and >>| for monadic bind & map *)
+open IO.Infix  (* opens infix operators >>= and >>| for monadic bind & map *)
 
 let store = FilesystemStore.create "testdata.zarr";;
 ```

--- a/zarr-eio/src/storage.mli
+++ b/zarr-eio/src/storage.mli
@@ -1,14 +1,14 @@
-module Deferred : Zarr.Types.Deferred with type 'a t = 'a
+module IO : Zarr.Types.IO with type 'a t = 'a
 
 (** An Eio-aware in-memory storage backend for Zarr v3 hierarchy. *)
-module MemoryStore : Zarr.Memory.S with module Deferred = Deferred
+module MemoryStore : Zarr.Memory.S with type 'a io := 'a
 
 (** An Eio-aware Zip file storage backend for a Zarr v3 hierarchy. *)
-module ZipStore : Zarr.Zip.S with module Deferred = Deferred
+module ZipStore : Zarr.Zip.S with type 'a io := 'a
 
 (** An Eio-aware local filesystem storage backend for a Zarr v3 hierarchy. *)
 module FilesystemStore : sig
-  include Zarr.Storage.STORE with module Deferred = Deferred
+  include Zarr.Storage.S with type 'a io := 'a
 
   val create : ?perm:Eio.File.Unix_perm.t -> env:<fs : Eio.Fs.dir_ty Eio.Path.t; ..> -> string -> t
   (** [create ~perm ~env dir] returns a new filesystem store.

--- a/zarr-lwt/src/storage.mli
+++ b/zarr-lwt/src/storage.mli
@@ -1,14 +1,14 @@
-module Deferred : Zarr.Types.Deferred with type 'a t = 'a Lwt.t
+module IO : Zarr.Types.IO with type 'a t = 'a Lwt.t
 
 (** An Lwt-aware in-memory storage backend for Zarr v3 hierarchy. *)
-module MemoryStore : Zarr.Memory.S with module Deferred = Deferred
+module MemoryStore : Zarr.Memory.S with type 'a io := 'a Lwt.t
 
 (** An Lwt-aware Zip file storage backend for a Zarr v3 hierarchy. *)
-module ZipStore : Zarr.Zip.S with module Deferred = Deferred
+module ZipStore : Zarr.Zip.S with type 'a io := 'a Lwt.t
 
 (** An Lwt-aware local filesystem storage backend for a Zarr V3 hierarchy. *)
 module FilesystemStore : sig
-  include Zarr.Storage.STORE with module Deferred = Deferred
+  include Zarr.Storage.S with type 'a io := 'a Lwt.t
 
   val create : ?perm:Unix.file_perm -> string -> t
   (** [create ~perm dir] returns a new filesystem store.
@@ -25,7 +25,7 @@ end
 module AmazonS3Store : sig
   exception Request_failed of Aws_s3_lwt.S3.error
 
-  include Zarr.Storage.STORE with module Deferred = Deferred
+  include Zarr.Storage.S with type 'a io := 'a Lwt.t
 
   val with_open :
     ?scheme:[ `Http | `Https ] ->

--- a/zarr-sync/src/storage.mli
+++ b/zarr-sync/src/storage.mli
@@ -1,14 +1,14 @@
-module Deferred : Zarr.Types.Deferred with type 'a t = 'a
+module IO : Zarr.Types.IO with type 'a t = 'a
 
 (** A blocking I/O in-memory storage backend for Zarr v3 hierarchy. *)
-module MemoryStore : Zarr.Memory.S with module Deferred = Deferred
+module MemoryStore : Zarr.Memory.S with type 'a io := 'a
 
 (** A blocking I/O Zip file storage backend for a Zarr v3 hierarchy. *)
-module ZipStore : Zarr.Zip.S with module Deferred = Deferred
+module ZipStore : Zarr.Zip.S with type 'a io := 'a
 
 (** A blocking I/O local filesystem storage backend for a Zarr v3 hierarchy. *)
 module FilesystemStore : sig
-  include Zarr.Storage.STORE with module Deferred = Deferred
+  include Zarr.Storage.S with type 'a io := 'a
 
   val create : ?perm:int -> string -> t
   (** [create ~perm dir] returns a new filesystem store.

--- a/zarr-sync/test/test_sync.ml
+++ b/zarr-sync/test/test_sync.ml
@@ -8,9 +8,7 @@ let string_of_list = [%show: string list]
 let print_node_pair = [%show: Node.Array.t list * Node.Group.t list]
 let print_int_array = [%show : int array]
 
-module type SYNC_STORE = sig
-  include Zarr.Storage.STORE with type 'a Deferred.t = 'a
-end
+module type SYNC_STORE = Zarr.Storage.S with type 'a io := 'a
 
 let test_storage
   (type a) (module M : SYNC_STORE with type t = a) (store : a) =
@@ -207,7 +205,7 @@ let _ =
       let zpath = tmp_dir ^ ".zip" in
       ZipStore.with_open `Read_write zpath (fun z -> test_storage (module ZipStore) z);
       (* test just opening the now exisitant archive created by the previous test. *)
-      ZipStore.with_open `Read_only zpath (fun _ -> ZipStore.Deferred.return_unit);
+      ZipStore.with_open `Read_only zpath (fun _ -> ());
       test_storage (module MemoryStore) @@ MemoryStore.create ();
       test_storage (module FilesystemStore) s)
   ])

--- a/zarr/src/codecs.mli
+++ b/zarr/src/codecs.mli
@@ -107,8 +107,7 @@ end
 
 (** A functor for generating a Sharding Indexed codec that supports partial
     (en/de)coding via IO operations. *)
-module Make (Io : Types.IO) : sig
-  open Io
+module Make (IO : Types.IO) : sig
 
   (** [is_just_sharding t] is [true] if the codec chain [t] contains only
       the [sharding_indexed] codec. *)
@@ -116,20 +115,20 @@ module Make (Io : Types.IO) : sig
 
   val partial_encode :
     Chain.t ->
-    ((int * int option) list -> string list Deferred.t) ->
-    (?append:bool -> (int * string) list -> unit Deferred.t) ->
+    (Types.range list -> string list IO.t) ->
+    (?append:bool -> (int * string) list -> unit IO.t) ->
     int ->
     'a array_repr ->
     (int array * 'a) list ->
     'a ->
-    unit Deferred.t
+    unit IO.t
 
   val partial_decode :
     Chain.t ->
-    ((int * int option) list -> string list Deferred.t) ->
+    (Types.range list -> string list IO.t) ->
     int ->
     'a array_repr ->
     (int * int array) list ->
     'a ->
-    (int * 'a) list Deferred.t
+    (int * 'a) list IO.t
 end

--- a/zarr/src/storage/storage.ml
+++ b/zarr/src/storage/storage.ml
@@ -1,14 +1,14 @@
 include Storage_intf
 
-module Make (Io : Types.IO) = struct
-  module Io_chain = Codecs.Make(Io)
-  module Deferred = Io.Deferred
+module Make (IO : Types.IO) (Store : Types.Store with type 'a io = 'a IO.t) = struct
+  module IO_chain = Codecs.Make(IO)
 
-  open Io
-  open Deferred.Infix
-  open Deferred.Syntax
+  open IO.Infix
+  open IO.Syntax
+  open Store
 
-  type t = Io.t
+  type t = Store.t
+  type 'a io = 'a IO.t
 
   let maybe_rename t old_name new_name = function
     | false -> raise (Key_not_found old_name)
@@ -27,29 +27,29 @@ module Make (Io : Types.IO) = struct
 
   let hierarchy t =
     let add ~t ((left, right) as acc) k =
-      if not (String.ends_with ~suffix:"zarr.json" k) then Deferred.return acc else
+      if not (String.ends_with ~suffix:"zarr.json" k) then IO.return acc else
       let path = if k = "zarr.json" then "/" else "/" ^ String.(sub k 0 (length k - 10)) in
-      Deferred.map (choose path left right) (node_kind t k)
+      IO.map (choose path left right) (node_kind t k)
     in
-    list t >>= Deferred.fold_left (add ~t) ([], [])
+    list t >>= IO.fold_left (add ~t) ([], [])
 
   let clear t = erase_prefix t ""
 
   module Group = struct
     let exists t node = is_member t (Node.Group.to_metakey node)
     let delete t node = erase_prefix t (Node.Group.to_prefix node)
-    let metadata t node = Deferred.map Metadata.Group.decode (get t @@ Node.Group.to_metakey node)
+    let metadata t node = IO.map Metadata.Group.decode (get t @@ Node.Group.to_metakey node)
 
     (* This recursively creates parent group nodes if they don't exist.*)
     let rec create ?(attrs=`Null) t node =
       let maybe_create ~attrs t node = function
-        | true -> Deferred.return_unit
+        | true -> IO.return_unit
         | false ->
           let key = Node.Group.to_metakey node
           and meta = Metadata.Group.(update_attributes default attrs) in
           let* () = set t key (Metadata.Group.encode meta) in
           match Node.Group.parent node with
-          | None -> Deferred.return_unit
+          | None -> IO.return_unit
           | Some p -> create t p
       in
       exists t node >>= maybe_create ~attrs t node
@@ -57,13 +57,13 @@ module Make (Io : Types.IO) = struct
     let children t node =
       let add ~t (left, right) prefix =
         let path = "/" ^ String.sub prefix 0 (String.length prefix - 1) in
-        Deferred.map (choose path left right) (node_kind t @@ prefix ^ "zarr.json")
+        IO.map (choose path left right) (node_kind t @@ prefix ^ "zarr.json")
       in
       let maybe_enumerate t node = function
-        | false -> Deferred.return ([], [])
+        | false -> IO.return ([], [])
         | true ->
           let* _, ps = list_dir t (Node.Group.to_prefix node) in
-          Deferred.fold_left (add ~t) ([], []) ps
+          IO.fold_left (add ~t) ([], []) ps
       in
       exists t node >>= maybe_enumerate t node
 
@@ -78,7 +78,7 @@ module Make (Io : Types.IO) = struct
     module Indexing = Ndarray.Indexing
     let exists t node = is_member t (Node.Array.to_metakey node)
     let delete t node = erase_prefix t (Node.Array.to_key node ^ "/")
-    let metadata t node = Deferred.map Metadata.Array.decode (get t @@ Node.Array.to_metakey node)
+    let metadata t node = IO.map Metadata.Array.decode (get t @@ Node.Array.to_metakey node)
 
     (* This recursively creates parent group nodes if they don't exist.*)
     let create ?(sep=`Slash) ?(dimension_names=[]) ?(attributes=`Null) ~codecs ~shape ~chunks kind fv node t =
@@ -87,7 +87,7 @@ module Make (Io : Types.IO) = struct
       let value = Metadata.Array.encode m in 
       let key = Node.Array.to_metakey node in
       let* () = set t key value in
-      Option.fold ~none:Deferred.return_unit ~some:(Group.create t) (Node.Array.parent node)
+      Option.fold ~none:IO.return_unit ~some:(Group.create t) (Node.Array.parent node)
 
     let write t node slice x =
       let update_ndarray ~arr (c, v) = Ndarray.set arr c v in
@@ -97,10 +97,10 @@ module Make (Io : Types.IO) = struct
       in
       let update_chunk ~t ~meta ~prefix ~chain ~fv ~repr (idx, pairs) =
         let ckey = prefix ^ Metadata.Array.chunk_key meta idx in
-        if Io_chain.is_just_sharding chain then
+        if IO_chain.is_just_sharding chain then
           let pget = get_partial_values t ckey and pset = set_partial_values t ckey in
           let* shardsize = size t ckey in
-          Io_chain.partial_encode chain pget pset shardsize repr pairs fv
+          IO_chain.partial_encode chain pget pset shardsize repr pairs fv
         else is_member t ckey >>= function
         | true ->
           let* v = get t ckey in
@@ -128,7 +128,7 @@ module Make (Io : Types.IO) = struct
       and prefix = Node.Array.to_key node ^ "/"
       and chain = Metadata.Array.codecs meta
       and bindings = ArrayMap.bindings m in
-      Deferred.iter (update_chunk ~t ~meta ~prefix ~chain ~fv ~repr) bindings
+      IO.iter (update_chunk ~t ~meta ~prefix ~chain ~fv ~repr) bindings
 
     let read (type a) t node slice (kind : a Ndarray.dtype) =
       let add_indexed_coord ~meta acc (i, y) =
@@ -138,10 +138,10 @@ module Make (Io : Types.IO) = struct
       let read_chunk ~t ~meta ~prefix ~chain ~fv ~repr (idx, pairs) =
         let ckey = prefix ^ Metadata.Array.chunk_key meta idx in
         size t ckey >>= function
-        | 0 -> Deferred.return @@ List.map (fun (i, _) -> i, fv) pairs
-        | shardsize when Io_chain.is_just_sharding chain ->
+        | 0 -> IO.return @@ List.map (fun (i, _) -> i, fv) pairs
+        | shardsize when IO_chain.is_just_sharding chain ->
           let pget = get_partial_values t ckey in
-          Io_chain.partial_decode chain pget shardsize repr pairs fv
+          IO_chain.partial_decode chain pget shardsize repr pairs fv
         | _ ->
           let+ v = get t ckey in
           let arr = Codecs.Chain.decode chain repr v in
@@ -159,7 +159,7 @@ module Make (Io : Types.IO) = struct
       and prefix = Node.Array.to_key node ^ "/"
       and fv = Metadata.Array.fillvalue_of_kind meta kind
       and repr = Codecs.{kind; shape = Metadata.Array.chunk_shape meta} in
-      let+ ps = Deferred.concat_map (read_chunk ~t ~meta ~prefix ~chain ~fv ~repr) (ArrayMap.bindings m) in
+      let+ ps = IO.concat_map (read_chunk ~t ~meta ~prefix ~chain ~fv ~repr) (ArrayMap.bindings m) in
       (* sorting restores the C-order of the decoded array coordinates.*)
       let sorted_pairs = List.fast_sort (fun (x, _) (y, _) -> Int.compare x y) ps in
       let vs = List.map snd sorted_pairs in
@@ -172,7 +172,7 @@ module Make (Io : Types.IO) = struct
       end)
       in
       let maybe_erase t key = function
-        | false -> Deferred.return_unit
+        | false -> IO.return_unit
         | true -> erase t key
       in
       let remove ~t ~meta ~prefix v =
@@ -186,7 +186,7 @@ module Make (Io : Types.IO) = struct
       and s' = S.of_list (Metadata.Array.chunk_indices meta new_shape) in
       let unreachable_chunks = S.elements (S.diff s s')
       and prefix = Node.Array.to_key node ^ "/" in
-      let* () = Deferred.iter (remove ~t ~meta ~prefix) unreachable_chunks in
+      let* () = IO.iter (remove ~t ~meta ~prefix) unreachable_chunks in
       set t (Node.Array.to_metakey node) Metadata.Array.(encode @@ update_shape meta new_shape)
 
     let rename t node str =

--- a/zarr/src/types.ml
+++ b/zarr/src/types.ml
@@ -1,4 +1,4 @@
-module type Deferred = sig
+module type IO = sig
   type 'a t
   val return : 'a -> 'a t
   val bind : 'a t -> ('a -> 'b t) -> 'b t
@@ -23,7 +23,7 @@ type value = string
 type range_start = int
 type prefix = string
 
-module type IO = sig
+module type Store = sig
   (** The abstract store interface that stores should implement.
 
       The store interface defines a set of operations involving keys and values.
@@ -39,20 +39,17 @@ module type IO = sig
       operations involving prefixes. In the context of this interface,
       a prefix is a string containing only characters that are valid for use
       in keys and ending with a trailing / character. *)
-
-  module Deferred : Deferred
-
   type t
-  val size : t -> key -> int Deferred.t
-  val get : t -> key -> value Deferred.t
-  val get_partial_values : t -> string -> range list -> value list Deferred.t
-  val set : t -> key -> value -> unit Deferred.t
-  val set_partial_values :
-    t -> key -> ?append:bool -> (range_start * value) list -> unit Deferred.t
-  val erase : t -> key -> unit Deferred.t
-  val erase_prefix : t -> key -> unit Deferred.t
-  val list : t -> key list Deferred.t
-  val list_dir : t -> key -> (key list * prefix list) Deferred.t
-  val is_member : t -> key -> bool Deferred.t
-  val rename : t -> key -> key -> unit Deferred.t
+  type 'a io
+  val size : t -> key -> int io
+  val get : t -> key -> value io
+  val get_partial_values : t -> string -> range list -> value list io
+  val set : t -> key -> value -> unit io
+  val set_partial_values : t -> key -> ?append:bool -> (range_start * value) list -> unit io
+  val erase : t -> key -> unit io
+  val erase_prefix : t -> key -> unit io
+  val list : t -> key list io
+  val list_dir : t -> key -> (key list * prefix list) io
+  val is_member : t -> key -> bool io
+  val rename : t -> key -> key -> unit io
 end


### PR DESCRIPTION
Also use destructive substituion where needed to make function signature return types more explicit.